### PR TITLE
WASM commitments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ categories = ["cryptography"]
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.0.9"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = "0.0.7"
+tari_utilities = "^0.1"
 base64 = "0.10.1"
 digest = "0.8.0"
 rand = "0.7.2"

--- a/README.md
+++ b/README.md
@@ -46,3 +46,15 @@ The benchmarks use Criterion and will produce nice graphs (if you have gnuplot i
 To run the benchmarks with SIMD instructions:
 
     $ cargo bench --features "avx2"
+
+# Change log
+
+## v0.2.0
+
+### General
+* WASM and crate version now match. Eliminate that confusion.
+
+### WASM module
+* Breaking change: `KeyRing.sign` doesn't take a nonce any more. It's not needed, and why risk someone re-using it?
+* New method: `key_utils.sign` to sign keys not in the key ring
+* New module: Commitments

--- a/wasm-demo.js
+++ b/wasm-demo.js
@@ -41,10 +41,7 @@ console.log("kA = ", keys.private_key("Alice"));
 console.log("PB = ", keys.public_key("Bob"));
 
 console.log("Signing message");
-let [r, R] = tari_crypto.generate_keypair();
-let sig = keys.sign("Alice", r, "Hello Tari");
-// The public nonce is returned in the signature. It should match R above
-assert.equal(R, sig.public_nonce);
+let sig = keys.sign("Alice", "Hello Tari");
 if (sig.error) {
     console.log(`Error getting signature ${sig.error}`);
 } else {
@@ -52,11 +49,27 @@ if (sig.error) {
     console.log("Verifying signature..");
     let pubkey = keys.public_key("Alice");
     console.log(`Pubkey: ${pubkey}`);
-    let check = tari_crypto.check_signature(R, sig.signature, pubkey, "Hello Tari");
-    if (check.result == true) {
+    let check = tari_crypto.check_signature(sig.public_nonce, sig.signature, pubkey, "Hello Tari");
+    if (check.result === true) {
         console.log("Signature is valid!");
     } else {
         console.log(`Invalid signature: ${check.error}`);
     }
 }
+
+// Commitments
+const v = BigInt(10200300);
+const k = keys.private_key("Bob");
+let commitment = tari_crypto.commit(k, v);
+if (commitment.error === true) {
+    console.log(`Commitment error: ${commitment.error}`);
+} else {
+    assert(tari_crypto.opens(k, v, commitment.commitment));
+    assert(!tari_crypto.opens(keys.private_key("Alice"), v, commitment.commitment));
+    console.log(`${commitment.commitment} commits to:\n (${k}, ${v})`)
+}
+let c2 = keys.commit("Bob", v);
+assert(c2.commitment, commitment.commitment);
 keys.free();
+
+


### PR DESCRIPTION
Bump version to 0.2.0

* Breaking change: `KeyRing.sign` doesn't take a nonce any more. It's not needed, and why risk someone re-using it?
* New method: `key_utils.sign` to sign keys not in the key ring
* New module: Commitments