### PR TITLE
Utils export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["cryptography"]
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2018"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,5 @@ pub mod ristretto;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
-// Re-export traits from tari_utils
-pub use tari_utilities::{hash::Hashable, hex::*, ByteArray, ByteArrayError};
+// Re-export tari_utils
+pub use tari_utilities;


### PR DESCRIPTION
export the whole `tari_utilities` crate rather than bits of it.
It makes using tari-crypto in other projects that also use tari_crypto
**much** more convenient.