### PR TITLE
Update tari_utilities dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.4.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = "^0.1"
+tari_utilities = "^0.2"
 base64 = "0.10.1"
 digest = "0.8.0"
 rand = "0.7.2"


### PR DESCRIPTION
That would allow to use traits from _tari_utilities:0.2_ for both _tari_crypto_ and _tari_mmr_
```
❯ cargo tree | less | grep tari   
emoji_id v0.1.0 (/Users/max/src/tari/emoji.id/emoji_id)
├── tari_crypto v0.4.0
│   └── tari_utilities v0.1.2
├── tari_mmr v0.2.0
│   ├── tari_storage v0.1.0
│   │   ├── tari_utilities v0.1.2 (*)
│   └── tari_utilities v0.2.0
```