### PR TITLE
Tari Script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.6.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = "^0.2"
+tari_utilities = "^0.3"
 base64 = "0.10.1"
 digest = "0.8.0"
 rand = "0.7.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,7 @@ pub mod ristretto;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
+pub mod script;
+
 // Re-export tari_utils
 pub use tari_utilities;

--- a/src/ristretto/ristretto_sig.rs
+++ b/src/ristretto/ristretto_sig.rs
@@ -102,26 +102,20 @@ pub type RistrettoSchnorr = SchnorrSignature<RistrettoPublicKey, RistrettoSecret
 mod test {
     use crate::{
         common::Blake256,
-        keys::{PublicKey, SecretKey},
+        keys::PublicKey,
         ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
     };
     use digest::Digest;
     use rand;
     use tari_utilities::ByteArray;
 
-    fn get_keypair() -> (RistrettoSecretKey, RistrettoPublicKey) {
-        let mut rng = rand::thread_rng();
-        let k = RistrettoSecretKey::random(&mut rng);
-        let pk = RistrettoPublicKey::from_secret_key(&k);
-        (k, pk)
-    }
-
     /// Create a signature, and then verify it. Also checks that some invalid signatures fail to verify
     #[test]
     #[allow(non_snake_case)]
     fn sign_and_verify_message() {
-        let (k, P) = get_keypair();
-        let (r, R) = get_keypair();
+        let mut rng = rand::thread_rng();
+        let (k, P) = RistrettoPublicKey::random_keypair(&mut rng);
+        let (r, R) = RistrettoPublicKey::random_keypair(&mut rng);
         let e = Blake256::new()
             .chain(P.as_bytes())
             .chain(R.as_bytes())
@@ -143,11 +137,12 @@ mod test {
     #[test]
     #[allow(non_snake_case)]
     fn test_signature_addition() {
+        let mut rng = rand::thread_rng();
         // Alice and Bob generate some keys and nonces
-        let (k1, P1) = get_keypair();
-        let (r1, R1) = get_keypair();
-        let (k2, P2) = get_keypair();
-        let (r2, R2) = get_keypair();
+        let (k1, P1) = RistrettoPublicKey::random_keypair(&mut rng);
+        let (r1, R1) = RistrettoPublicKey::random_keypair(&mut rng);
+        let (k2, P2) = RistrettoPublicKey::random_keypair(&mut rng);
+        let (r2, R2) = RistrettoPublicKey::random_keypair(&mut rng);
         // Each of them creates the Challenge = H(R1 || R2 || P1 || P2 || m)
         let e = Blake256::new()
             .chain(R1.as_bytes())

--- a/src/ristretto/utils.rs
+++ b/src/ristretto/utils.rs
@@ -1,17 +1,12 @@
-// Copyright 2019 The Tari Project
-//
+// Copyright 2020. The Tari Project
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
-//
 // 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
 // disclaimer.
-//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
 // following disclaimer in the documentation and/or other materials provided with the distribution.
-//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
 // products derived from this software without specific prior written permission.
-//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 // INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -20,21 +15,43 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod constants;
-pub mod dalek_range_proof;
-pub mod musig;
-pub mod pedersen;
-pub mod ristretto_keys;
-pub mod ristretto_sig;
-pub mod serialize;
-pub mod utils;
+//! Handy utility functions for use in tests and demo scripts
 
-// Re-export
-pub use self::{
-    ristretto_keys::{RistrettoPublicKey, RistrettoSecretKey},
-    ristretto_sig::RistrettoSchnorr,
+use crate::{
+    keys::PublicKey,
+    ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
+    signatures::SchnorrSignatureError,
 };
+use digest::Digest;
+use tari_utilities::ByteArray;
 
-// test modules
-#[cfg(test)]
-mod test_common;
+/// A set of keys and it's associated signature
+pub struct SignatureSet {
+    pub nonce: RistrettoSecretKey,
+    pub public_nonce: RistrettoPublicKey,
+    pub message: Vec<u8>,
+    pub signature: RistrettoSchnorr,
+}
+
+/// Generate a random keypair and a signature for the provided message
+///
+/// # Panics
+///
+/// The function panics if it cannot generate a suitable signature
+pub fn sign<D: Digest>(
+    private_key: &RistrettoSecretKey,
+    message: &[u8],
+) -> Result<SignatureSet, SchnorrSignatureError>
+{
+    let mut rng = rand::thread_rng();
+    let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut rng);
+    let message = D::new().chain(public_nonce.as_bytes()).chain(message).result().to_vec();
+    let e = RistrettoSecretKey::from_bytes(&message).map_err(|_| SchnorrSignatureError::InvalidChallenge)?;
+    let s = RistrettoSchnorr::sign(private_key.clone(), nonce.clone(), e.as_bytes())?;
+    Ok(SignatureSet {
+        nonce,
+        public_nonce,
+        message,
+        signature: s,
+    })
+}

--- a/src/script/error.rs
+++ b/src/script/error.rs
@@ -1,17 +1,12 @@
-// Copyright 2019 The Tari Project
-//
+// Copyright 2020. The Tari Project
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
-//
 // 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
 // disclaimer.
-//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
 // following disclaimer in the documentation and/or other materials provided with the distribution.
-//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
 // products derived from this software without specific prior written permission.
-//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 // INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -19,22 +14,33 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+use crate::ristretto::pedersen::PedersenCommitment;
+use thiserror::Error;
 
-pub mod constants;
-pub mod dalek_range_proof;
-pub mod musig;
-pub mod pedersen;
-pub mod ristretto_keys;
-pub mod ristretto_sig;
-pub mod serialize;
-pub mod utils;
-
-// Re-export
-pub use self::{
-    ristretto_keys::{RistrettoPublicKey, RistrettoSecretKey},
-    ristretto_sig::RistrettoSchnorr,
-};
-
-// test modules
-#[cfg(test)]
-mod test_common;
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum ScriptError {
+    #[error("The script failed with an explicit Return")]
+    Return,
+    #[error("The stack cannot exceed MAX_STACK_SIZE items")]
+    StackOverflow,
+    #[error("The script completed execution with a stack size other than one")]
+    NonUnitLengthStack,
+    #[error("The script completed execution with a non-zero value: {0}")]
+    NonZeroValue(i64),
+    #[error("Tried to pop an element off an empty stack")]
+    StackUnderflow,
+    #[error("An operand was applied to incompatible types")]
+    IncompatibleTypes,
+    #[error("A script opcode resulted in a value that exceeded the maximum or minimum value")]
+    ValueExceedsBounds,
+    #[error("The script result is not a zero commitment")]
+    NonZeroCommitment(PedersenCommitment),
+    #[error("The script encountered an invalid opcode")]
+    InvalidOpcode,
+    #[error("The script ended without there being a single zero-valued item on the stack")]
+    IncorrectFinalState,
+    #[error("The script contained an invalid signature")]
+    InvalidSignature,
+    #[error("A verification opcode failed, aborting the script immediately")]
+    VerifyFailed,
+}

--- a/src/script/error.rs
+++ b/src/script/error.rs
@@ -41,6 +41,8 @@ pub enum ScriptError {
     IncorrectFinalState,
     #[error("The script contained an invalid signature")]
     InvalidSignature,
+    #[error("The serialised stack contained invalid input")]
+    InvalidInput,
     #[error("A verification opcode failed, aborting the script immediately")]
     VerifyFailed,
 }

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -1,17 +1,12 @@
-// Copyright 2019 The Tari Project
-//
+// Copyright 2020. The Tari Project
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
-//
 // 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
 // disclaimer.
-//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
 // following disclaimer in the documentation and/or other materials provided with the distribution.
-//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
 // products derived from this software without specific prior written permission.
-//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 // INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -20,21 +15,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod constants;
-pub mod dalek_range_proof;
-pub mod musig;
-pub mod pedersen;
-pub mod ristretto_keys;
-pub mod ristretto_sig;
-pub mod serialize;
-pub mod utils;
+mod error;
+mod op_codes;
+mod serde;
+mod tari_script;
 
-// Re-export
-pub use self::{
-    ristretto_keys::{RistrettoPublicKey, RistrettoSecretKey},
-    ristretto_sig::RistrettoSchnorr,
-};
-
-// test modules
-#[cfg(test)]
-mod test_common;
+pub use op_codes::Opcode;
+pub use tari_script::{Builder, ExecutionStack, StackItem, TariScript};

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -18,7 +18,9 @@
 mod error;
 mod op_codes;
 mod serde;
+mod stack;
 mod tari_script;
 
 pub use op_codes::Opcode;
-pub use tari_script::{Builder, ExecutionStack, StackItem, TariScript};
+pub use stack::{ExecutionStack, StackItem};
+pub use tari_script::{Builder, TariScript};

--- a/src/script/op_codes.rs
+++ b/src/script/op_codes.rs
@@ -1,0 +1,224 @@
+// Copyright 2020. The Tari Project
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{fmt, ops::Deref};
+use tari_utilities::hex::Hex;
+
+pub type HashValue = [u8; 32];
+
+/// Convert a slice into a HashValue.
+///
+/// # Panics
+///
+/// The function does not check slice for length at all.  You need to check this / guarantee it yourself.
+pub fn to_hash(slice: &[u8]) -> Box<HashValue> {
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(slice);
+    Box::new(hash)
+}
+
+// Opcode constants: Script termination
+pub const OP_RETURN: u8 = 0x60;
+
+// Opcode constants: Stack manipulation
+pub const OP_DROP: u8 = 0x70;
+pub const OP_DUP: u8 = 0x71;
+pub const OP_REV_ROT: u8 = 0x72;
+pub const OP_PUSH_HASH: u8 = 0x7a;
+
+// Opcode constants: Comparisons
+pub const OP_EQUAL: u8 = 0x80;
+pub const OP_EQUAL_VERIFY: u8 = 0x81;
+
+// Opcode constants: Arithmetic
+pub const OP_ADD: u8 = 0x93;
+pub const OP_SUB: u8 = 0x94;
+
+// Opcode constants: Cryptography
+pub const OP_CHECK_SIG: u8 = 0xac;
+pub const OP_CHECK_SIG_VERIFY: u8 = 0xad;
+pub const OP_HASH_BLAKE256: u8 = 0xb0;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Opcode {
+    /// Push the associated 32-byte value onto the stack
+    PushHash(Box<HashValue>),
+    /// Hash to top stack element with the Blake256 hash function and push the result to the stack
+    HashBlake256,
+    /// Fail the script immediately. (Must be executed.)
+    Return,
+    /// Drops the top stack item
+    Drop,
+    /// Duplicates the top stack item
+    Dup,
+    /// Reverse rotation. The top stack item moves into 3rd place, abc => bca
+    RevRot,
+    /// Pop two items and push their sum
+    Add,
+    /// Pop two items and push the second minus the top
+    Sub,
+    /// Pop the public key and then the signature. If the signature signs the script, push 0 to the stack, otherwise
+    /// push 1
+    CheckSig,
+    /// As for CheckSig, but aborts immediately if the signature is invalid. As opposed to Bitcoin, it pushes a zero
+    /// to the stack if successful
+    CheckSigVerify,
+    /// Pushes 0, if the inputs are exactly equal, 1 otherwise
+    Equal,
+    /// Pushes 0, if the inputs are exactly equal, aborts otherwise
+    EqualVerify,
+}
+
+impl Opcode {
+    /// Take a byte slice an read the next opcode from it, including any associated data. `read_next` returns a tuple
+    /// of the deserialised opcode, and an updated slice that has the Opcode and data removed.
+    pub fn read_next(bytes: &[u8]) -> Option<(Opcode, &[u8])> {
+        let code = bytes.get(0)?;
+        match *code {
+            OP_RETURN => Some((Opcode::Return, &bytes[1..])),
+            OP_DROP => Some((Opcode::Drop, &bytes[1..])),
+            OP_DUP => Some((Opcode::Dup, &bytes[1..])),
+            OP_REV_ROT => Some((Opcode::RevRot, &bytes[1..])),
+            OP_EQUAL => Some((Opcode::Equal, &bytes[1..])),
+            OP_EQUAL_VERIFY => Some((Opcode::EqualVerify, &bytes[1..])),
+            OP_ADD => Some((Opcode::Add, &bytes[1..])),
+            OP_SUB => Some((Opcode::Sub, &bytes[1..])),
+            OP_CHECK_SIG => Some((Opcode::CheckSig, &bytes[1..])),
+            OP_CHECK_SIG_VERIFY => Some((Opcode::CheckSigVerify, &bytes[1..])),
+            OP_HASH_BLAKE256 => Some((Opcode::HashBlake256, &bytes[1..])),
+            OP_PUSH_HASH => {
+                if bytes.len() < 33 {
+                    return None;
+                }
+                let hash = to_hash(&bytes[1..33]);
+                Some((Opcode::PushHash(hash), &bytes[33..]))
+            },
+            _ => None,
+        }
+    }
+
+    /// Convert an opcode into its binary representation and append it to the array. The function returns the byte slice
+    /// that matches the opcode as a convenience
+    pub fn to_bytes<'a>(&self, array: &'a mut Vec<u8>) -> &'a [u8] {
+        let n = array.len();
+        let len = match self {
+            // Simple matches
+            Opcode::Return => {
+                array.push(OP_RETURN);
+                1usize
+            },
+            Opcode::Drop => {
+                array.push(OP_DROP);
+                1
+            },
+            Opcode::Dup => {
+                array.push(OP_DUP);
+                1
+            },
+            Opcode::Equal => {
+                array.push(OP_EQUAL);
+                1
+            },
+            Opcode::EqualVerify => {
+                array.push(OP_EQUAL_VERIFY);
+                1
+            },
+            Opcode::Add => {
+                array.push(OP_ADD);
+                1
+            },
+            Opcode::Sub => {
+                array.push(OP_SUB);
+                1
+            },
+            Opcode::CheckSig => {
+                array.push(OP_CHECK_SIG);
+                1
+            },
+            Opcode::CheckSigVerify => {
+                array.push(OP_CHECK_SIG_VERIFY);
+                1
+            },
+            Opcode::RevRot => {
+                array.push(OP_REV_ROT);
+                1
+            },
+            Opcode::HashBlake256 => {
+                array.push(OP_HASH_BLAKE256);
+                1
+            },
+            // Complex matches
+            Opcode::PushHash(h) => {
+                array.push(OP_PUSH_HASH);
+                array.extend_from_slice(h.deref());
+                0x21
+            },
+        };
+        &array[n..n + len]
+    }
+}
+
+impl fmt::Display for Opcode {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use Opcode::*;
+        match self {
+            HashBlake256 => fmt.write_str("HashBlake256"),
+            Return => fmt.write_str("Return"),
+            Drop => fmt.write_str("Drop"),
+            Dup => fmt.write_str("Dup"),
+            RevRot => fmt.write_str("RevRot"),
+            Add => fmt.write_str("Add"),
+            Sub => fmt.write_str("Sub"),
+            CheckSig => fmt.write_str("CheckSig"),
+            CheckSigVerify => fmt.write_str("CheckSigVerify"),
+            Equal => fmt.write_str("Equal"),
+            EqualVerify => fmt.write_str("EqualVerify"),
+            PushHash(h) => fmt.write_str(&format!("PushHash({})", (*h).to_hex())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::script::{Opcode, Opcode::*};
+
+    #[test]
+    fn empty_script() {
+        assert!(Opcode::read_next(&[]).is_none())
+    }
+
+    #[test]
+    fn read_next() {
+        let script = [0x60u8, 0x71, 0x00];
+        let (code, b) = Opcode::read_next(&script).unwrap();
+        assert_eq!(code, Return);
+        let (code, b) = Opcode::read_next(b).unwrap();
+        assert_eq!(code, Dup);
+        assert!(Opcode::read_next(b).is_none());
+        assert!(Opcode::read_next(&[0x7a]).is_none());
+    }
+
+    #[test]
+    fn push_hash() {
+        let (code, b) = Opcode::read_next(b"\x7a/thirty-two~character~hash~val./").unwrap();
+        match code {
+            PushHash(v) if &*v == b"/thirty-two~character~hash~val./" => {},
+            _ => panic!("Did bot decode push hash"),
+        }
+        assert!(b.is_empty());
+    }
+}

--- a/src/script/op_codes.rs
+++ b/src/script/op_codes.rs
@@ -84,7 +84,7 @@ pub enum Opcode {
 }
 
 impl Opcode {
-    /// Take a byte slice an read the next opcode from it, including any associated data. `read_next` returns a tuple
+    /// Take a byte slice and read the next opcode from it, including any associated data. `read_next` returns a tuple
     /// of the deserialised opcode, and an updated slice that has the Opcode and data removed.
     pub fn read_next(bytes: &[u8]) -> Option<(Opcode, &[u8])> {
         let code = bytes.get(0)?;

--- a/src/script/op_codes.rs
+++ b/src/script/op_codes.rs
@@ -115,60 +115,26 @@ impl Opcode {
     /// that matches the opcode as a convenience
     pub fn to_bytes<'a>(&self, array: &'a mut Vec<u8>) -> &'a [u8] {
         let n = array.len();
-        let len = match self {
+        match self {
             // Simple matches
-            Opcode::Return => {
-                array.push(OP_RETURN);
-                1usize
-            },
-            Opcode::Drop => {
-                array.push(OP_DROP);
-                1
-            },
-            Opcode::Dup => {
-                array.push(OP_DUP);
-                1
-            },
-            Opcode::Equal => {
-                array.push(OP_EQUAL);
-                1
-            },
-            Opcode::EqualVerify => {
-                array.push(OP_EQUAL_VERIFY);
-                1
-            },
-            Opcode::Add => {
-                array.push(OP_ADD);
-                1
-            },
-            Opcode::Sub => {
-                array.push(OP_SUB);
-                1
-            },
-            Opcode::CheckSig => {
-                array.push(OP_CHECK_SIG);
-                1
-            },
-            Opcode::CheckSigVerify => {
-                array.push(OP_CHECK_SIG_VERIFY);
-                1
-            },
-            Opcode::RevRot => {
-                array.push(OP_REV_ROT);
-                1
-            },
-            Opcode::HashBlake256 => {
-                array.push(OP_HASH_BLAKE256);
-                1
-            },
+            Opcode::Return => array.push(OP_RETURN),
+            Opcode::Drop => array.push(OP_DROP),
+            Opcode::Dup => array.push(OP_DUP),
+            Opcode::Equal => array.push(OP_EQUAL),
+            Opcode::EqualVerify => array.push(OP_EQUAL_VERIFY),
+            Opcode::Add => array.push(OP_ADD),
+            Opcode::Sub => array.push(OP_SUB),
+            Opcode::CheckSig => array.push(OP_CHECK_SIG),
+            Opcode::CheckSigVerify => array.push(OP_CHECK_SIG_VERIFY),
+            Opcode::RevRot => array.push(OP_REV_ROT),
+            Opcode::HashBlake256 => array.push(OP_HASH_BLAKE256),
             // Complex matches
             Opcode::PushHash(h) => {
                 array.push(OP_PUSH_HASH);
                 array.extend_from_slice(h.deref());
-                0x21
             },
         };
-        &array[n..n + len]
+        &array[n..]
     }
 }
 

--- a/src/script/serde.rs
+++ b/src/script/serde.rs
@@ -1,0 +1,81 @@
+// Copyright 2020. The Tari Project
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::script::TariScript;
+use serde::{
+    de::{Error, Visitor},
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
+};
+use std::fmt;
+use tari_utilities::hex::{from_hex, Hex};
+
+impl Serialize for TariScript {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        let script_bin = self.as_bytes();
+        if ser.is_human_readable() {
+            ser.serialize_str(&script_bin.to_hex())
+        } else {
+            ser.serialize_bytes(&script_bin)
+        }
+    }
+}
+
+struct ScriptVisitor;
+
+impl<'de> Visitor<'de> for ScriptVisitor {
+    type Value = TariScript;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Expecting a binary array or hex string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where E: Error {
+        let bytes = from_hex(v).map_err(|e| E::custom(e.to_string()))?;
+        self.visit_bytes(&bytes)
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where E: Error {
+        self.visit_str(&v)
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where E: Error {
+        TariScript::from_bytes(&v).map_err(|e| E::custom(e.to_string()))
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+    where E: Error {
+        self.visit_bytes(v)
+    }
+}
+
+impl<'de> Deserialize<'de> for TariScript {
+    fn deserialize<D>(de: D) -> Result<Self, D::Error>
+    where D: Deserializer<'de> {
+        if de.is_human_readable() {
+            de.deserialize_string(ScriptVisitor)
+        } else {
+            de.deserialize_bytes(ScriptVisitor)
+        }
+    }
+}

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -1,0 +1,106 @@
+// Copyright 2020. The Tari Project
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    ristretto::{pedersen::PedersenCommitment, RistrettoPublicKey, RistrettoSchnorr},
+    script::{error::ScriptError, op_codes::HashValue},
+};
+
+pub const MAX_STACK_SIZE: usize = 256;
+
+#[macro_export]
+macro_rules! inputs {
+    ($($input:expr),+) => {{
+        use crate::script::{ExecutionStack, StackItem};
+
+        let items = vec![$(StackItem::from($input)),+];
+        ExecutionStack::new(items)
+    }}
+}
+
+macro_rules! stack_item_from {
+    ($from_type:ty => $variant:ident) => {
+        impl From<$from_type> for StackItem {
+            fn from(item: $from_type) -> Self {
+                StackItem::$variant(item)
+            }
+        }
+    };
+}
+
+#[derive(Debug, Clone)]
+pub enum StackItem {
+    Number(i64),
+    Hash(HashValue),
+    Commitment(PedersenCommitment),
+    PublicKey(RistrettoPublicKey),
+    Signature(RistrettoSchnorr),
+}
+
+stack_item_from!(i64 => Number);
+stack_item_from!(PedersenCommitment => Commitment);
+stack_item_from!(RistrettoPublicKey => PublicKey);
+stack_item_from!(RistrettoSchnorr => Signature);
+
+#[derive(Debug, Default, Clone)]
+pub struct ExecutionStack {
+    items: Vec<StackItem>,
+}
+
+impl ExecutionStack {
+    pub fn new(items: Vec<StackItem>) -> Self {
+        ExecutionStack { items }
+    }
+
+    pub fn size(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn peek(&self) -> Option<&StackItem> {
+        self.items.last()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn pop(&mut self) -> Option<StackItem> {
+        self.items.pop()
+    }
+
+    pub fn push(&mut self, item: StackItem) -> Result<(), ScriptError> {
+        if self.size() >= MAX_STACK_SIZE {
+            return Err(ScriptError::StackOverflow);
+        }
+        self.items.push(item);
+        Ok(())
+    }
+
+    /// Pushes the top stack element down `depth` positions
+    pub(crate) fn push_down(&mut self, depth: usize) -> Result<(), ScriptError> {
+        let n = self.size();
+        if n < depth + 1 {
+            return Err(ScriptError::StackUnderflow);
+        }
+        if depth == 0 {
+            return Ok(());
+        }
+        let top = self.pop().unwrap();
+        self.items.insert(n - depth - 1, top);
+        Ok(())
+    }
+}

--- a/src/script/tari_script.rs
+++ b/src/script/tari_script.rs
@@ -390,6 +390,11 @@ mod test {
             TariScript::from_hex("71b07aae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e58170ac")
                 .unwrap();
         assert_eq!(script.execute(&inp), Ok(()));
+        // Try again with invalid sig
+        let inp = ExecutionStack::from_hex("0500b7c695528c858cde76dab3076908e01228b6dbdd5f671bed1b03\
+        b89e170c314c7b413e971dbb85879ba990e851607454da4bdf65839456d7cac19e5a338f060456c0fa32558d6edc0916baa26b48e745de8\
+        34571534ca253ea82435f08ebbc7c").unwrap();
+        assert_eq!(script.execute(&inp), Err(ScriptError::NonZeroValue(1)));
     }
 
     #[test]

--- a/src/script/tari_script.rs
+++ b/src/script/tari_script.rs
@@ -1,0 +1,497 @@
+// Copyright 2020. The Tari Project
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    common::Blake256,
+    ristretto::{pedersen::PedersenCommitment, RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
+    script::{
+        error::ScriptError,
+        op_codes::{HashValue, Opcode},
+    },
+};
+use blake2::Digest;
+use std::fmt;
+use tari_utilities::{
+    hex::{from_hex, to_hex, Hex, HexError},
+    ByteArray,
+};
+
+#[macro_export]
+macro_rules! script {
+    ($($opcode:ident$(($var:expr))?) +) => {{
+        use crate::script::TariScript;
+        use crate::script::Opcode;
+        let script = vec![$(Opcode::$opcode $(($var))?),+];
+        TariScript::new(script)
+    }}
+}
+
+#[macro_export]
+macro_rules! inputs {
+    ($($input:expr),+) => {{
+        use crate::script::ExecutionStack;
+
+        let items = vec![$(crate::script::StackItem::from($input)),+];
+        ExecutionStack { items }
+    }}
+}
+
+macro_rules! stack_item_from {
+    ($from_type:ty => $variant:ident) => {
+        impl From<$from_type> for StackItem {
+            fn from(item: $from_type) -> Self {
+                StackItem::$variant(item)
+            }
+        }
+    };
+}
+
+pub const MAX_STACK_SIZE: usize = 256;
+
+#[derive(Debug, Clone)]
+pub enum StackItem {
+    Number(i64),
+    Hash(HashValue),
+    Commitment(PedersenCommitment),
+    PublicKey(RistrettoPublicKey),
+    Signature(RistrettoSchnorr),
+}
+
+stack_item_from!(PedersenCommitment => Commitment);
+stack_item_from!(RistrettoPublicKey => PublicKey);
+stack_item_from!(RistrettoSchnorr => Signature);
+
+#[derive(Debug, Default, Clone)]
+pub struct ExecutionStack {
+    items: Vec<StackItem>,
+}
+
+impl ExecutionStack {
+    pub fn new() -> Self {
+        ExecutionStack::default()
+    }
+
+    pub fn size(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn peek(&self) -> Option<&StackItem> {
+        self.items.last()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn pop(&mut self) -> Option<StackItem> {
+        self.items.pop()
+    }
+
+    pub fn push(&mut self, item: StackItem) -> Result<(), ScriptError> {
+        if self.size() >= MAX_STACK_SIZE {
+            return Err(ScriptError::StackOverflow);
+        }
+        self.items.push(item);
+        Ok(())
+    }
+
+    /// Pushes the top stack element down `depth` positions
+    fn push_down(&mut self, depth: usize) -> Result<(), ScriptError> {
+        let n = self.size();
+        if n < depth + 1 {
+            return Err(ScriptError::StackUnderflow);
+        }
+        if depth == 0 {
+            return Ok(());
+        }
+        let top = self.pop().unwrap();
+        self.items.insert(n - depth - 1, top);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TariScript {
+    script: Vec<Opcode>,
+}
+
+impl TariScript {
+    pub fn new(script: Vec<Opcode>) -> Self {
+        TariScript { script }
+    }
+
+    pub fn execute(&self, inputs: &ExecutionStack) -> Result<(), ScriptError> {
+        // Copy all inputs onto the stack
+        let mut stack = inputs.clone();
+        for opcode in self.script.iter() {
+            self.execute_opcode(opcode, &mut stack)?
+        }
+        TariScript::stack_is_zero(&stack)
+    }
+
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.script.iter().fold(Vec::with_capacity(512), |mut bytes, op| {
+            op.to_bytes(&mut bytes);
+            bytes
+        })
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ScriptError> {
+        let mut script = Vec::with_capacity(512);
+        let mut byte_str = bytes;
+        while !byte_str.is_empty() {
+            match Opcode::read_next(byte_str) {
+                Some((code, b)) => {
+                    script.push(code);
+                    byte_str = b;
+                },
+                None => return Err(ScriptError::InvalidOpcode),
+            }
+        }
+        Ok(TariScript { script })
+    }
+
+    pub fn to_opcodes(&self) -> Vec<String> {
+        self.script.iter().map(|op| op.to_string()).collect()
+    }
+
+    /// Calculate the message hash that CHECKSIG uses to verify signatures
+    pub fn script_message(&self, pub_key: &RistrettoPublicKey) -> Result<RistrettoSecretKey, ScriptError> {
+        let b = Blake256::new()
+            .chain(pub_key.as_bytes())
+            .chain(&self.as_bytes())
+            .result();
+        RistrettoSecretKey::from_bytes(b.as_slice()).map_err(|_| ScriptError::InvalidSignature)
+    }
+
+    fn execute_opcode(&self, opcode: &Opcode, stack: &mut ExecutionStack) -> Result<(), ScriptError> {
+        use StackItem::*;
+        match opcode {
+            Opcode::Return => Err(ScriptError::Return),
+            Opcode::Add => TariScript::handle_op_add(stack),
+            Opcode::Sub => TariScript::handle_op_sub(stack),
+            Opcode::Dup => TariScript::handle_dup(stack),
+            Opcode::Drop => TariScript::handle_drop(stack),
+            Opcode::Equal => match TariScript::handle_equal(stack)? {
+                true => stack.push(Number(0)),
+                false => stack.push(Number(1)),
+            },
+            Opcode::EqualVerify => match TariScript::handle_equal(stack)? {
+                true => stack.push(Number(0)),
+                false => Err(ScriptError::VerifyFailed),
+            },
+            Opcode::CheckSig => match self.check_sig(stack)? {
+                true => stack.push(Number(0)),
+                false => stack.push(Number(1)),
+            },
+            Opcode::CheckSigVerify => match self.check_sig(stack)? {
+                true => stack.push(Number(0)),
+                false => Err(ScriptError::InvalidSignature),
+            },
+            Opcode::RevRot => stack.push_down(2),
+            Opcode::PushHash(h) => stack.push(StackItem::Hash(*h.clone())),
+            Opcode::HashBlake256 => TariScript::handle_hash::<Blake256>(stack),
+        }
+    }
+
+    /// Handle opcodes that push a hash to the stack. I'm not doing any length checks right now, so this should be
+    /// added once other digest functions are provided that don't produce 32 byte hashes
+    fn handle_hash<D: Digest>(stack: &mut ExecutionStack) -> Result<(), ScriptError> {
+        use StackItem::*;
+        let top = stack.pop().ok_or(ScriptError::StackUnderflow)?;
+        // use a closure to grab &b while it still exists in the match expression
+        let to_arr = |b: &[u8]| {
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(D::digest(b).as_slice());
+            hash
+        };
+        let hash_value = match top {
+            Commitment(c) => to_arr(c.as_bytes()),
+            PublicKey(k) => to_arr(k.as_bytes()),
+            Hash(h) => to_arr(&h),
+            _ => return Err(ScriptError::IncompatibleTypes),
+        };
+
+        stack.push(Hash(hash_value))
+    }
+
+    fn handle_dup(stack: &mut ExecutionStack) -> Result<(), ScriptError> {
+        let last = if let Some(last) = stack.items.last() {
+            last.clone()
+        } else {
+            return Err(ScriptError::StackUnderflow);
+        };
+        stack.push(last)
+    }
+
+    fn handle_drop(stack: &mut ExecutionStack) -> Result<(), ScriptError> {
+        match stack.pop() {
+            Some(_) => Ok(()),
+            None => Err(ScriptError::StackUnderflow),
+        }
+    }
+
+    fn handle_op_add(stack: &mut ExecutionStack) -> Result<(), ScriptError> {
+        use StackItem::*;
+        let top = stack.pop().ok_or(ScriptError::StackUnderflow)?;
+        let two = stack.pop().ok_or(ScriptError::StackUnderflow)?;
+        match (top, two) {
+            (Number(v1), Number(v2)) => stack.push(Number(v1.checked_add(v2).ok_or(ScriptError::ValueExceedsBounds)?)),
+            (Commitment(c1), Commitment(c2)) => stack.push(Commitment(&c1 + &c2)),
+            (PublicKey(p1), PublicKey(p2)) => stack.push(PublicKey(&p1 + &p2)),
+            (Signature(s1), Signature(s2)) => stack.push(Signature(&s1 + &s2)),
+            (_, _) => Err(ScriptError::IncompatibleTypes),
+        }
+    }
+
+    fn handle_op_sub(stack: &mut ExecutionStack) -> Result<(), ScriptError> {
+        use StackItem::*;
+        let top = stack.pop().ok_or(ScriptError::StackUnderflow)?;
+        let two = stack.pop().ok_or(ScriptError::StackUnderflow)?;
+        match (top, two) {
+            (Number(v1), Number(v2)) => stack.push(Number(v2.checked_sub(v1).ok_or(ScriptError::ValueExceedsBounds)?)),
+            (Commitment(c1), Commitment(c2)) => stack.push(Commitment(&c2 - &c1)),
+            (..) => Err(ScriptError::IncompatibleTypes),
+        }
+    }
+
+    fn handle_equal(stack: &mut ExecutionStack) -> Result<bool, ScriptError> {
+        use StackItem::*;
+        let top = stack.pop().ok_or(ScriptError::StackUnderflow)?;
+        let two = stack.pop().ok_or(ScriptError::StackUnderflow)?;
+        match (top, two) {
+            (Number(v1), Number(v2)) => Ok(v1 == v2),
+            (Commitment(c1), Commitment(c2)) => Ok(c1 == c2),
+            (Signature(s1), Signature(s2)) => Ok(s1 == s2),
+            (PublicKey(p1), PublicKey(p2)) => Ok(p1 == p2),
+            (Hash(h1), Hash(h2)) => Ok(h1 == h2),
+            (..) => Err(ScriptError::IncompatibleTypes),
+        }
+    }
+
+    fn check_sig(&self, stack: &mut ExecutionStack) -> Result<bool, ScriptError> {
+        use StackItem::*;
+        let pk = stack.pop().ok_or(ScriptError::StackUnderflow)?;
+        let sig = stack.pop().ok_or(ScriptError::StackUnderflow)?;
+        match (pk, sig) {
+            (PublicKey(p), Signature(s)) => {
+                let m = self.script_message(&p)?;
+                Ok(s.verify(&p, &m))
+            },
+            (..) => Err(ScriptError::IncompatibleTypes),
+        }
+    }
+
+    fn stack_is_zero(stack: &ExecutionStack) -> Result<(), ScriptError> {
+        if stack.size() != 1 {
+            return Err(ScriptError::NonUnitLengthStack);
+        }
+        use StackItem::*;
+        match stack.peek().unwrap() {
+            Number(0) => Ok(()),
+            Number(v) => Err(ScriptError::NonZeroValue(*v)),
+            Commitment(c) if c.as_public_key() == &RistrettoPublicKey::default() => Ok(()),
+            Commitment(c) => Err(ScriptError::NonZeroCommitment(c.clone())),
+            _ => Err(ScriptError::IncorrectFinalState),
+        }
+    }
+}
+
+impl Hex for TariScript {
+    fn from_hex(hex: &str) -> Result<Self, HexError>
+    where Self: Sized {
+        let bytes = from_hex(hex)?;
+        TariScript::from_bytes(&bytes).map_err(|_| HexError::HexConversionError)
+    }
+
+    fn to_hex(&self) -> String {
+        to_hex(&self.as_bytes())
+    }
+}
+
+impl fmt::Display for TariScript {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = self.to_opcodes().join(" ");
+        f.write_str(&s)
+    }
+}
+
+#[derive(Default)]
+pub struct Builder {}
+
+impl Builder {
+    pub fn new() -> Self {
+        Builder {}
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        common::Blake256,
+        keys::{PublicKey, SecretKey},
+        ristretto::{pedersen::PedersenCommitment, RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
+        script::{
+            error::ScriptError,
+            op_codes::to_hash,
+            tari_script::{ExecutionStack, StackItem::*},
+            TariScript,
+        },
+    };
+    use blake2::Digest;
+    use tari_utilities::{hex::Hex, ByteArray};
+
+    #[test]
+    fn op_return() {
+        let script = script!(Return);
+        let inputs = ExecutionStack::new();
+        assert_eq!(script.execute(&inputs), Err(ScriptError::Return));
+    }
+
+    #[test]
+    fn op_add() {
+        let script = script!(Add);
+        let inputs = inputs!(Number(3), Number(2));
+        assert_eq!(script.execute(&inputs), Err(ScriptError::NonZeroValue(5)));
+        let inputs = inputs!(Number(3), Number(-3));
+        assert!(script.execute(&inputs).is_ok());
+        let inputs = inputs!(Number(i64::MAX), Number(1));
+        assert_eq!(script.execute(&inputs), Err(ScriptError::ValueExceedsBounds));
+        let inputs = inputs!(Number(1));
+        assert_eq!(script.execute(&inputs), Err(ScriptError::StackUnderflow));
+    }
+
+    #[test]
+    fn op_add_commitments() {
+        let script = script!(Add);
+        let mut rng = rand::thread_rng();
+        let (_, c1) = RistrettoPublicKey::random_keypair(&mut rng);
+        let (_, c2) = RistrettoPublicKey::random_keypair(&mut rng);
+        let c3 = &c1 + &c2;
+        let c3 = PedersenCommitment::from_public_key(&c3);
+        let inputs = inputs!(
+            Commitment(PedersenCommitment::from_public_key(&c1)),
+            Commitment(PedersenCommitment::from_public_key(&c2))
+        );
+        assert_eq!(script.execute(&inputs), Err(ScriptError::NonZeroCommitment(c3)));
+    }
+
+    #[test]
+    fn op_sub() {
+        let script = script!(Add Sub);
+        let inputs = inputs!(Number(5), Number(3), Number(2));
+        assert!(script.execute(&inputs).is_ok());
+        let inputs = inputs!(Number(i64::MAX), Number(1));
+        assert_eq!(script.execute(&inputs), Err(ScriptError::ValueExceedsBounds));
+        let script = script!(Sub);
+        let inputs = inputs!(Number(5), Number(3));
+        assert_eq!(script.execute(&inputs), Err(ScriptError::NonZeroValue(2)));
+    }
+
+    #[test]
+    fn serialisation() {
+        let script = script!(Add Sub Add);
+        assert_eq!(&script.as_bytes(), &[0x93, 0x94, 0x93]);
+        assert_eq!(TariScript::from_bytes(&[0x93, 0x94, 0x93]).unwrap(), script);
+        assert_eq!(script.to_hex(), "939493");
+        assert_eq!(TariScript::from_hex("939493").unwrap(), script);
+    }
+
+    #[test]
+    fn check_sig() {
+        let mut rng = rand::thread_rng();
+        let (k, p) = RistrettoPublicKey::random_keypair(&mut rng);
+        let r = RistrettoSecretKey::random(&mut rng);
+        let script = script!(CheckSig);
+        let m = script.script_message(&p).unwrap();
+        let s = RistrettoSchnorr::sign(k.clone(), r.clone(), m.as_bytes()).unwrap();
+        let inputs = inputs!(s, p);
+        assert!(script.execute(&inputs).is_ok());
+    }
+
+    #[test]
+    fn check_sig_verify() {
+        let mut rng = rand::thread_rng();
+        let (k, p) = RistrettoPublicKey::random_keypair(&mut rng);
+        let r = RistrettoSecretKey::random(&mut rng);
+        let script = script!(CheckSigVerify);
+        let m = script.script_message(&p).unwrap();
+        let s = RistrettoSchnorr::sign(k.clone(), r.clone(), m.as_bytes()).unwrap();
+        let inputs = inputs!(s, p);
+        assert!(script.execute(&inputs).is_ok());
+    }
+
+    #[test]
+    fn add_partial_signatures() {
+        let mut rng = rand::thread_rng();
+        let (k1, p1) = RistrettoPublicKey::random_keypair(&mut rng);
+        let (k2, p2) = RistrettoPublicKey::random_keypair(&mut rng);
+        let r1 = RistrettoSecretKey::random(&mut rng);
+        let r2 = RistrettoSecretKey::random(&mut rng);
+        let script = script!(Add RevRot Add CheckSigVerify);
+        let m = script.script_message(&(&p1 + &p2)).unwrap();
+        let s1 = RistrettoSchnorr::sign(k1.clone(), r1.clone(), m.as_bytes()).unwrap();
+        let s2 = RistrettoSchnorr::sign(k2.clone(), r2.clone(), m.as_bytes()).unwrap();
+        let inputs = inputs!(p1, p2, s1, s2);
+        assert_eq!(script.execute(&inputs), Ok(()));
+    }
+
+    #[test]
+    fn pay_to_public_key_hash() {
+        let k =
+            RistrettoSecretKey::from_hex("7212ac93ee205cdbbb57c4f0f815fbf8db25b4d04d3532e2262e31907d82c700").unwrap();
+        let p = RistrettoPublicKey::from_secret_key(&k); // 56c0fa32558d6edc0916baa26b48e745de834571534ca253ea82435f08ebbc7c
+        let r =
+            RistrettoSecretKey::from_hex("193ee873f3de511eda8ae387db6498f3d194d31a130a94cdf13dc5890ec1ad0f").unwrap();
+        let hash = Blake256::digest(p.as_bytes());
+        let pkh = to_hash(hash.as_slice()); // ae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e5
+        let script = script!(Dup HashBlake256 PushHash(pkh) EqualVerify Drop CheckSig);
+        let hex_script = "71b07aae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e58170ac";
+        // Test serialisation
+        assert_eq!(script.to_hex(), hex_script);
+        // Test de-serialisation
+        assert_eq!(TariScript::from_hex(hex_script).unwrap(), script);
+        let m = script.script_message(&p).unwrap();
+        let sig = RistrettoSchnorr::sign(k, r, m.as_bytes()).unwrap();
+        // The top of the stack is the right-most element!
+        let inputs = inputs!(sig, p);
+        assert_eq!(script.execute(&inputs), Ok(()));
+    }
+
+    #[test]
+    fn disassemble() {
+        let hex_script = "71b07aae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e58170ac";
+        let script = TariScript::from_hex(hex_script).unwrap();
+        let ops = vec![
+            "Dup",
+            "HashBlake256",
+            "PushHash(ae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e5)",
+            "EqualVerify",
+            "Drop",
+            "CheckSig",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+        assert_eq!(script.to_opcodes(), ops);
+        assert_eq!(
+            script.to_string(),
+            "Dup HashBlake256 PushHash(ae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e5) EqualVerify \
+             Drop CheckSig"
+        );
+    }
+}

--- a/src/script/tari_script.rs
+++ b/src/script/tari_script.rs
@@ -382,6 +382,17 @@ mod test {
     }
 
     #[test]
+    fn hex_only() {
+        let inp = ExecutionStack::from_hex("0500f7c695528c858cde76dab3076908e01228b6dbdd5f671bed1b03\
+        b89e170c314c7b413e971dbb85879ba990e851607454da4bdf65839456d7cac19e5a338f060456c0fa32558d6edc0916baa26b48e745de8\
+        34571534ca253ea82435f08ebbc7c").unwrap();
+        let script =
+            TariScript::from_hex("71b07aae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e58170ac")
+                .unwrap();
+        assert_eq!(script.execute(&inp), Ok(()));
+    }
+
+    #[test]
     fn disassemble() {
         let hex_script = "71b07aae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e58170ac";
         let script = TariScript::from_hex(hex_script).unwrap();


### PR DESCRIPTION
Tari script is heavily inspired by Bitcoin script in that:
* It is non-Turing complete
* Is stack based
* Shares many of the same opcodes

For script safety, the Rust type system is leveraged so that
* Opcode operations on inappropriate input data is impossible
* Bounds checking is done on arithmetic operations

Tari script differs from Bitcoin script in that:
* Succesful execution requires exactly zero to be on the stack after
completion
* Blake256 and Curve25519 are the default hash and elliptic curves
respectively.

For a PoC, pay-to-public-key-hash (P2PKH) is implemented in the tests.

Serde support is provided.

## OpCodeS:

```
#[derive(Debug, Clone, PartialEq, Eq)]
pub enum Opcode {
    /// Push the associated 32-byte value onto the stack
    PushHash(Box<HashValue>),
    /// Hash to top stack element with the Blake256 hash function and push the result to the stack
    HashBlake256,
    /// Fail the script immediately. (Must be executed.)
    Return,
    /// Drops the top stack item
    Drop,
    /// Duplicates the top stack item
    Dup,
    /// Reverse rotation. The top stack item moves into 3rd place, abc => bca
    RevRot,
    /// Pop two items and push their sum
    Add,
    /// Pop two items and push the second minus the top
    Sub,
    /// Pop the public key and then the signature. If the signature signs the script, push 0 to the stack, otherwise
    /// push 1
    CheckSig,
    /// As for CheckSig, but aborts immediately if the signature is invalid. As opposed to Bitcoin, it pushes a zero
    /// to the stack if successful
    CheckSigVerify,
    /// Pushes 0, if the inputs are exactly equal, 1 otherwise
    Equal,
    /// Pushes 0, if the inputs are exactly equal, aborts otherwise
    EqualVerify,
}
```

## Stack types

```
pub enum StackItem {
pub enum StackItem {
    Number(i64),
    Hash(HashValue),
    Commitment(PedersenCommitment),
    PublicKey(RistrettoPublicKey),
    Signature(RistrettoSchnorr),
}
```

The tests demonstrate how scripts can be constructed and executed:


```
    fn pay_to_public_key_hash() {
        let k = RistrettoSecretKey::from_hex("7212ac93ee205cdbbb57c4f0f815fbf8db25b4d04d3532e2262e31907d82c700").unwrap();
        let p = RistrettoPublicKey::from_secret_key(&k); // 56c0fa32558d6edc0916baa26b48e745de834571534ca253ea82435f08ebbc7c
        let r =
            RistrettoSecretKey::from_hex("193ee873f3de511eda8ae387db6498f3d194d31a130a94cdf13dc5890ec1ad0f").unwrap();
        let hash = Blake256::digest(p.as_bytes());
        let pkh = to_hash(hash.as_slice()); // ae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e5
        let script = script!(Dup HashBlake256 PushHash(pkh) EqualVerify Drop CheckSig);
        let hex_script = "71b07aae2337ce44f9ebb6169c863ec168046cb35ab4ef7aa9ed4f5f1f669bb74b09e58170ac";

        let m = script.script_message(&p).unwrap();
        let sig = RistrettoSchnorr::sign(k, r, m.as_bytes()).unwrap();
        // The top of the stack is the right-most element!
        let inputs = inputs!(sig, p);
        assert_eq!(script.execute(&inputs), Ok(()));
    }
```