### PR TITLE
Add Sha3 hash function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ curve25519-dalek = { version = "2.0.0" }
 bulletproofs = { version = "2.0.0" }
 merlin = "2.0.0"
 sha2 = "0.8.0"
+sha3 = "0.9"
 thiserror = "1.0.20"
 blake2 = "0.8.1"
 blake3 = "0.3"


### PR DESCRIPTION
Add sha3 as a hash function for tari_crypto
Refactor crypto to better accommodate more than one hash function. 

This Pr adds in the sh3 as a hash function. Its added in the same way as as blake2. This will allow tari to swop hash functions between the two with just the changed of a type. 

The tari_crypto crate is also modified to allow more than one hash function to be supported easily. 
Added a pub use to not break the moving of the blake2 hash function. 