### PR TITLE
Fix wasm_build for new version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ crate-type = ["lib", "cdylib"]
 name = "benches"
 path = "benches/mod.rs"
 harness = false
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]


### PR DESCRIPTION
A recent change in wasm_builder broke the existing WASM code.
This PR enables the global mutable flag to maintain compatibility with
the old wasm builder.