### PR TITLE
Align dalek version numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["cryptography"]
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 
 [dependencies]
@@ -16,8 +16,8 @@ base64 = "0.10.1"
 digest = "0.8.0"
 rand = "0.7.2"
 clear_on_drop = "=0.2.4"
-curve25519-dalek = { version = "3.0.0" }
-bulletproofs = {git = "https://github.com/tari-project/bulletproofs", version = "^2.0.0" , branch="develop"}
+curve25519-dalek = { version = "2" }
+bulletproofs = {version = "2.1.0" , package="tari_bulletproofs"}
 merlin = "2.0.0"
 sha2 = "0.8.0"
 sha3 = "0.9"

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,6 @@ fn main() {
     if needs_ffi {
         generate_ffi_header();
     }
-    generate_ffi_header();
 }
 
 fn generate_ffi_header() {


### PR DESCRIPTION
* Match bulletproof and tari_crypto dependency versions
* Bump crtate version to v0.8.1