### PR TITLE
Bump cbindgen dep to fix security audit on Tari repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ criterion = "0.2"
 bincode = "1.1.4"
 
 [build-dependencies]
-cbindgen = "0.6.6"
+cbindgen = "0.16.0"
 
 [features]
 default = []

--- a/libtari/demo.c
+++ b/libtari/demo.c
@@ -18,7 +18,8 @@ int main() {
     const char *ver = version();
     printf("Tari Crypto (v%s)\n", ver);
 
-    uint8_t pub_key[KEY_LENGTH], priv_key[KEY_LENGTH];
+    uint8_t pub_key[KEY_LENGTH];
+    uint8_t priv_key[KEY_LENGTH];
 
     int code = random_keypair(&priv_key, &pub_key);
     if (code) {
@@ -33,7 +34,8 @@ int main() {
     const char msg[] = "Hello world\0";
     const char invalid[] = "Hullo world\0";
 
-    uint8_t r[KEY_LENGTH], sig[KEY_LENGTH];
+    uint8_t r[KEY_LENGTH];
+    uint8_t sig[KEY_LENGTH];
 
     code = sign(&priv_key, &msg[0], &r, &sig);
     if (code) {

--- a/src/ffi/keys.rs
+++ b/src/ffi/keys.rs
@@ -27,7 +27,7 @@ use rand::rngs::OsRng;
 use std::{ffi::CStr, os::raw::c_int};
 use tari_utilities::ByteArray;
 
-const KEY_LENGTH: usize = 32;
+pub const KEY_LENGTH: usize = 32;
 
 type KeyArray = [u8; KEY_LENGTH];
 


### PR DESCRIPTION
The security audit was failing on tari-project/tari because it had a higher required version of `serde`, which became a transitive dependency of this repo with the introduction of` cbindgen`. 

This PR updates to cbindgen dependency, and fixes some build issues encountered afterwards. 

Tested with:
- [x] `make demo && ./bin/demo` still works correctly
- [x] `cargo test` pass 