### PR TITLE
Fix grcov action

### DIFF
--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -16,10 +16,11 @@ jobs:
       - name: Download Rust
         uses: actions-rs/toolchain@v1
       - name: Build
-        run: cargo test --all-features --no-fail-fast
+        run: cargo test --all-features --no-fail-fast --lib
         env:
+          CARGO_FEATURE_FFI: '0'
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
       - name: Run test coverage
         id: coverage

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ use cbindgen::Config;
 use std::{env, path::Path};
 
 fn main() {
-    let needs_ffi = env::var("CARGO_FEATURE_FFI").is_ok();
+    let needs_ffi = &env::var("CARGO_FEATURE_FFI").unwrap_or_default() == "1";
     if needs_ffi {
         generate_ffi_header();
     }


### PR DESCRIPTION
* Only run lib tests (doc tests shouldn't count towards coverage)
* Fix stack overflow issue -- don't run FFI binding generation and change panic strategy 