### PR TITLE
Add compile flags to dependencies for wasm32 target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ avx2 = ["curve25519-dalek/avx2_backend", "bulletproofs/avx2_backend"]
 wasm = ["wasm-bindgen", "clear_on_drop/no_cc", "rand/wasm-bindgen", "rand/getrandom"]
 ffi = ["libc"]
 
+[target.wasm32-unknown-unknown.dependencies]
+clear_on_drop = { features = ["no_cc"] }
+rand = { features = ["getrandom"] }
+
 [lib]
 # Disable benchmarks to allow Criterion to take over
 bench = false


### PR DESCRIPTION
When compiling tari_crypto as dependency, when we do not need to include it's exports it is failing now with compile error:
```
  process didn't exit successfully:  (exit code: 1)
  --- stdout
  TARGET = Some(wasm32-unknown-unknown)
```

This change fixes that issue. Worked for me on when I updated dependency to:
```
tari_crypto = { version = "0.8.0", git = "https://github.com/dunnock/tari-crypto", branch = "dunnock-wasm32-dependencies" }
```