### PR TITLE
Expose fine-grained control of cc feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["cryptography"]
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2018"
 
 [dependencies]
@@ -37,13 +37,15 @@ criterion = "0.2"
 bincode = "1.1.4"
 
 [build-dependencies]
-cbindgen = "0.16.0"
+cbindgen = "0.17.0"
 
 [features]
 default = []
 avx2 = ["curve25519-dalek/avx2_backend", "bulletproofs/avx2_backend"]
-wasm = ["wasm-bindgen", "clear_on_drop/no_cc", "rand/wasm-bindgen", "rand/getrandom"]
+wasm = ["wasm-bindgen", "rand/wasm-bindgen", "rand/getrandom"]
 ffi = ["libc"]
+no_cc_nightly = ["clear_on_drop/nightly"]
+no_cc = ["clear_on_drop/no_cc"]
 
 [lib]
 # Disable benchmarks to allow Criterion to take over

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,9 @@ demo: $(BIN)/demo
 ffi: target/debug/libtari_crypto.a
 
 ffi-release: target/release/libtari_crypto.a
+
+wasm:
+	wasm-pack build . -- --features "wasm, no_cc_nightly"
+
+wasm-node:
+	wasm-pack build --target nodejs -d tari_js . -- --features "wasm, no_cc_nightly"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To build the WebAssembly module, the `wasm` feature must be enabled:
 To generate a module for use in node.js, use this command:
 
     $ wasm-pack build --target nodejs -d tari_js . -- --features "wasm"
+
+If you receive compoiler errors related to `clear_on_drop`, then add the `no_cc` or `no_cc_nightly` feature flags.
     
 Note: Node v10+ is needed for the WASM 
 


### PR DESCRIPTION
This PR resolves two inter-related issues:

* Tari_crypto WASM doesn't work on Safari currently
* wasm_pack won't compile `clear_on_drop` (need to use either `no_cc` or `nightly` flags)

The latter was fixed by including the `no-cc` flag in the `wasm` flag. This causes issues with libraries that use tari_crypto as a dependency for building wasm, but don't want to export the wasm functions defined here. So they either cannot build, or they switch on the `wasm` feature, but then Safari isn't supported.

This PR simply decouples the two issues.

You can export wasm with the `wasm` flag; and control the `clear_on_drop` compilation using either the `no_cc` or `no_cc_nightly` flags.
