### PR TITLE
Update TariScript/opcodes and implementation to latest RFC-0202 

### DIFF
--- a/src/ristretto/musig.rs
+++ b/src/ristretto/musig.rs
@@ -143,10 +143,7 @@ impl<D: Digest> RistrettoMuSig<D> {
 
     /// Convenience wrapper function to determined whether a signing ceremony has failed
     pub fn has_failed(&self) -> bool {
-        match self.state {
-            MuSigState::Failed(_) => true,
-            _ => false,
-        }
+        matches!(self.state, MuSigState::Failed(_))
     }
 
     /// IF `has_failed()` is true, you can obtain the specific error that caused the failure
@@ -159,34 +156,22 @@ impl<D: Digest> RistrettoMuSig<D> {
 
     /// Convenience function to determine whether we're in Round One of MuSig (nonce hash collection)
     pub fn is_collecting_hashes(&self) -> bool {
-        match self.state {
-            MuSigState::NonceHashCollection(_) => true,
-            _ => false,
-        }
+        matches!(self.state, MuSigState::NonceHashCollection(_))
     }
 
     /// Convenience function to determine whether we'rein Round Two of MuSig (public nonce collection)
     pub fn is_collecting_nonces(&self) -> bool {
-        match self.state {
-            MuSigState::NonceCollection(_) => true,
-            _ => false,
-        }
+        matches!(self.state, MuSigState::NonceCollection(_))
     }
 
     /// Convenience function to determine whether we're in Round Three of MuSig (partial signature collection)
     pub fn is_collecting_signatures(&self) -> bool {
-        match self.state {
-            MuSigState::SignatureCollection(_) => true,
-            _ => false,
-        }
+        matches!(self.state, MuSigState::SignatureCollection(_))
     }
 
     /// Convenience function to determine whether The MuSig protocol is complete (the aggregate signature is ready)
     pub fn is_finalized(&self) -> bool {
-        match self.state {
-            MuSigState::Finalized(_) => true,
-            _ => false,
-        }
+        matches!(self.state, MuSigState::Finalized(_))
     }
 
     /// Return the index of the public key in the MuSig ceremony. If were still collecting public keys, the state has

--- a/src/script/error.rs
+++ b/src/script/error.rs
@@ -14,8 +14,11 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use crate::ristretto::pedersen::PedersenCommitment;
+
+use std::num::TryFromIntError;
+
 use serde::{Deserialize, Serialize};
+use tari_utilities::ByteArrayError;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Error, PartialEq, Eq, Serialize, Deserialize)]
@@ -26,26 +29,36 @@ pub enum ScriptError {
     StackOverflow,
     #[error("The script completed execution with a stack size other than one")]
     NonUnitLengthStack,
-    #[error("The script completed execution with a non-zero value: {0}")]
-    NonZeroValue(i64),
     #[error("Tried to pop an element off an empty stack")]
     StackUnderflow,
     #[error("An operand was applied to incompatible types")]
     IncompatibleTypes,
     #[error("A script opcode resulted in a value that exceeded the maximum or minimum value")]
     ValueExceedsBounds,
-    #[error("The script result is not a zero commitment")]
-    NonZeroCommitment(PedersenCommitment),
     #[error("The script encountered an invalid opcode")]
     InvalidOpcode,
-    #[error("The script ended without there being a single zero-valued item on the stack")]
-    IncorrectFinalState,
+    #[error("The script is missing closing opcodes (Else or EndIf)")]
+    MissingOpcode,
     #[error("The script contained an invalid signature")]
     InvalidSignature,
     #[error("The serialised stack contained invalid input")]
     InvalidInput,
+    #[error("The script contained invalid data")]
+    InvalidData,
     #[error("A verification opcode failed, aborting the script immediately")]
     VerifyFailed,
     #[error("as_hash requires a Digest function that returns at least 32 bytes")]
     InvalidDigest,
+}
+
+impl From<TryFromIntError> for ScriptError {
+    fn from(_err: TryFromIntError) -> ScriptError {
+        ScriptError::ValueExceedsBounds
+    }
+}
+
+impl From<ByteArrayError> for ScriptError {
+    fn from(_err: ByteArrayError) -> ScriptError {
+        ScriptError::InvalidData
+    }
 }

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -23,10 +23,10 @@ mod stack;
 mod tari_script;
 
 pub use error::ScriptError;
-pub use op_codes::{to_boxed_hash, to_hash, HashValue, Opcode};
+pub use op_codes::{slice_to_boxed_hash, slice_to_hash, HashValue, Opcode};
 pub use script_context::ScriptContext;
 pub use stack::{ExecutionStack, StackItem};
-pub use tari_script::{Builder, TariScript};
+pub use tari_script::TariScript;
 
 // As hex: c5a1ea6d3e0a6a0d650c99489bcd563e37a06221fd04b8f3a842a982b2813907
 pub const DEFAULT_SCRIPT_HASH: HashValue = [


### PR DESCRIPTION
Opcodes and script logic updated from [RFC-0202](https://rfc.tari.com/RFC-0202_TariScriptOpcodes.html). Includes tests for new opcodes. 