### PR TITLE
Add serde to the ExecutionStack

### DIFF
--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -31,7 +31,7 @@ pub const MAX_STACK_SIZE: usize = 256;
 #[macro_export]
 macro_rules! inputs {
     ($($input:expr),+) => {{
-        use crate::script::{ExecutionStack, StackItem};
+        use $crate::script::{ExecutionStack, StackItem};
 
         let items = vec![$(StackItem::from($input)),+];
         ExecutionStack::new(items)

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -21,11 +21,11 @@ use crate::{
     ristretto::{pedersen::PedersenCommitment, RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
     script::{error::ScriptError, op_codes::HashValue},
 };
+use serde::{Deserialize, Serialize};
 use tari_utilities::{
     hex::{from_hex, to_hex, Hex, HexError},
     ByteArray,
 };
-
 pub const MAX_STACK_SIZE: usize = 256;
 
 #[macro_export]
@@ -54,7 +54,7 @@ pub const TYPE_COMMITMENT: u8 = 3;
 pub const TYPE_PUBKEY: u8 = 4;
 pub const TYPE_SIG: u8 = 5;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StackItem {
     Number(i64),
     Hash(HashValue),
@@ -158,7 +158,7 @@ stack_item_from!(PedersenCommitment => Commitment);
 stack_item_from!(RistrettoPublicKey => PublicKey);
 stack_item_from!(RistrettoSchnorr => Signature);
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionStack {
     items: Vec<StackItem>,
 }

--- a/src/script/tari_script.rs
+++ b/src/script/tari_script.rs
@@ -41,8 +41,8 @@ use tari_utilities::{
 #[macro_export]
 macro_rules! script {
     ($($opcode:ident$(($var:expr))?) +) => {{
-        use crate::script::TariScript;
-        use crate::script::Opcode;
+        use $crate::script::TariScript;
+        use $crate::script::Opcode;
         let script = vec![$(Opcode::$opcode $(($var))?),+];
         TariScript::new(script)
     }}


### PR DESCRIPTION
Make storing the ExecutionStack in a database easier, this was manually implemented for TariScript but I think the derives are fine for the stack.