### PR TITLE
Add `to_vec` function to comm sig

### DIFF
--- a/src/ristretto/ristretto_com_sig.rs
+++ b/src/ristretto/ristretto_com_sig.rs
@@ -102,10 +102,11 @@ mod test {
     use crate::{
         commitment::HomomorphicCommitmentFactory,
         common::Blake256,
-        keys::SecretKey,
+        keys::{PublicKey, SecretKey},
         ristretto::{
             pedersen::{PedersenCommitment, PedersenCommitmentFactory},
             RistrettoComSig,
+            RistrettoPublicKey,
             RistrettoSecretKey,
         },
     };
@@ -212,5 +213,18 @@ mod test {
         let k_1 = RistrettoSecretKey::random(&mut rng);
         let k_2 = RistrettoSecretKey::random(&mut rng);
         assert!(RistrettoComSig::sign(a_value, x_value, k_2, k_1, &message, &factory).is_ok());
+    }
+
+    #[test]
+    fn to_vec() {
+        let sig = RistrettoComSig::default();
+        let bytes = sig.to_vec();
+
+        assert_eq!(
+            bytes.capacity(),
+            RistrettoPublicKey::key_length() + RistrettoSecretKey::key_length() * 2
+        );
+        assert_eq!(bytes.capacity(), bytes.len());
+        assert!(bytes.iter().all(|b| *b == 0x00));
     }
 }

--- a/src/signatures/commitment_signature.rs
+++ b/src/signatures/commitment_signature.rs
@@ -178,6 +178,15 @@ where
     pub fn public_nonce(&self) -> &HomomorphicCommitment<P> {
         &self.public_nonce
     }
+
+    /// Returns a canonical byte representation of the commitment signature
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(P::key_length() + K::key_length() + K::key_length());
+        buf.extend_from_slice(self.public_nonce().as_bytes());
+        buf.extend_from_slice(self.u().as_bytes());
+        buf.extend_from_slice(self.v().as_bytes());
+        buf
+    }
 }
 
 impl<'a, 'b, P, K> Add<&'b CommitmentSignature<P, K>> for &'a CommitmentSignature<P, K>
@@ -285,6 +294,6 @@ where
     K: SecretKey,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(&[self.public_nonce().as_bytes(), self.u().as_bytes(), self.v().as_bytes()].concat())
+        state.write(&self.to_vec())
     }
 }


### PR DESCRIPTION
This implements the canonical way to encode CommitmentSignature.
i.e `bytes(R) || bytes(u) || bytes(v)`

Unfortunately, implementing `ByteArray` is not possible (maybe with unsafe) as things stand 
because the trait requires `as_bytes` to be implemented which implies 
something owns the contiguous bytes that the slice is referencing, which is not the case.

## Usage

The script_signature needs to be committed to in the input hash. ~~One way to do that is to calculate `uG + vH` where `u` and `v` are the public signatures (i.e use  `calc_signature_verifier(&CommitmentFactory::default()).as_bytes()`. However, this requires all clients to be able to create commitments on G and H (extra wasm bindings etc) vs simply concatenating bytes.~~ EDIT: was obviously tired ;) can  just use `bytes(u)`, `bytes(v)` and `bytes(nonce)`. Perhaps this is still useful, otherwise feel free to close.