### PR TITLE
Minor clippy fixes

### DIFF
--- a/src/script/op_codes.rs
+++ b/src/script/op_codes.rs
@@ -464,7 +464,7 @@ impl fmt::Display for Opcode {
 
 #[cfg(test)]
 mod test {
-    use crate::script::{op_codes::*, stack::StackItem::PublicKey, Opcode, Opcode::*, ScriptError};
+    use crate::script::{op_codes::*, Opcode, Opcode::*, ScriptError};
 
     #[test]
     fn empty_script() {
@@ -629,7 +629,7 @@ mod test {
             assert!(matches!(Opcode::read_next(&[val]), Err(ScriptError::InvalidData)));
             let s = &[val, 5, 83];
             let (opcode, rem) = Opcode::read_next(s).unwrap();
-            assert!(matches!(opcode, op));
+            assert_eq!(opcode, op);
             assert_eq!(rem, &[83]);
             // Deserialise
             let mut arr = vec![];
@@ -652,7 +652,7 @@ mod test {
                 70, 21, 54, 61, 18, 97, 167, 93, 163, 228, 1,
             ];
             let (opcode, rem) = Opcode::read_next(msg).unwrap();
-            assert!(matches!(opcode, op));
+            assert_eq!(opcode, op);
             assert!(rem.is_empty());
             // Deserialise
             let mut arr = vec![];

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -212,14 +212,14 @@ impl ExecutionStack {
 
         // check that all popped items are of the same variant
         // first count each variant
-        let counts = items.iter().fold([0; 5], |values, item| counter(values, item));
+        let counts = items.iter().fold([0; 5], counter);
         // also check the n + 1 item
         let counts = counter(counts, &item);
 
         // then filter those with more than 0
-        let distict_variants: Vec<&u8> = counts.iter().filter(|&c| c > &0).collect();
+        let num_distinct_variants = counts.iter().filter(|&c| *c > 0).count();
 
-        if distict_variants.len() > 1 {
+        if num_distinct_variants > 1 {
             return Err(ScriptError::InvalidInput);
         }
 


### PR DESCRIPTION
- [minor perf] Use count instead of collect in `pop_n_plus_one_contains`
- [test] Use `PartialEq` impl instead of `matches!` to check non-static
  `Opcode` 

~~Not very intuitively, `assert!(matches!(opcode, op))` is producing a `match opcode` and `op` is placed in the catch-all position, so not testing the match at all~~ see comments