### PR TITLE
WASM unit tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+# For wasm-* targets, the wasm-bindgen-test runner must be used
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tari_utilities = "^0.3"
 base64 = "0.10.1"
 digest = "0.9.0"
 rand = { version = "0.8", default-features = false }
+getrandom = { version = "0.2.3", default-features = false, optional = true }
 clear_on_drop = "=0.2.4"
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, features = ["u64_backend", "serde", "alloc"] }
 bulletproofs = {version = "4.0.0", package="tari_bulletproofs"}
@@ -34,6 +35,7 @@ wasm-bindgen = { version = "^0.2", features = ["serde-serialize"], optional = tr
 criterion = "0.3.4"
 bincode = "1.1.4"
 blake3 = "0.3"
+wasm-bindgen-test = "0.3.24"
 
 [build-dependencies]
 cbindgen = "0.17.0"
@@ -46,7 +48,7 @@ default = ["no_cc"]
 #                                          ^^^^^^^^^^^^ feature has been removed
 # feature error on subtle-ng
 avx2 = ["curve25519-dalek/avx2_backend", "bulletproofs/avx2_backend"]
-wasm = ["wasm-bindgen",  "rand/getrandom"]
+wasm = ["wasm-bindgen",  "getrandom/js"]
 ffi = ["libc"]
 no_cc_nightly = ["clear_on_drop/nightly"]
 no_cc = ["clear_on_drop/no_cc"]

--- a/src/script/op_codes.rs
+++ b/src/script/op_codes.rs
@@ -464,7 +464,7 @@ impl fmt::Display for Opcode {
 
 #[cfg(test)]
 mod test {
-    use crate::script::{op_codes::*, stack::StackItem::PublicKey, Opcode, Opcode::*, ScriptError};
+    use crate::script::{op_codes::*, Opcode, Opcode::*, ScriptError};
 
     #[test]
     fn empty_script() {

--- a/src/wasm/keyring.rs
+++ b/src/wasm/keyring.rs
@@ -161,3 +161,169 @@ impl KeyRing {
         self.factory.open_value(k, value, &commitment)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{hash::blake2::Blake256, keys::SecretKey, ristretto::RistrettoSchnorr};
+    use blake2::{digest::Output, Digest};
+    use wasm_bindgen_test::*;
+
+    const SAMPLE_CHALLENGE: &str = "გამარჯობა";
+
+    fn new_keyring() -> KeyRing {
+        let mut kr = KeyRing::new();
+        kr.new_key("a".into());
+        kr.new_key("b".into());
+        kr
+    }
+
+    fn hash<T: AsRef<[u8]>>(preimage: T) -> Output<Blake256> {
+        Blake256::digest(preimage.as_ref())
+    }
+
+    fn create_commitment(k: &RistrettoSecretKey, v: u64) -> PedersenCommitment {
+        PedersenCommitmentFactory::default().commit_value(k, v)
+    }
+
+    impl KeyRing {
+        fn expect_public_key(&self, id: &str) -> &RistrettoPublicKey {
+            let (_, pk) = self.keys.get(id).unwrap();
+            pk
+        }
+
+        fn expect_private_key(&self, id: &str) -> &RistrettoSecretKey {
+            let (sk, _) = self.keys.get(id).unwrap();
+            sk
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn it_has_an_empty_default() {
+        let kr = KeyRing::default();
+        assert!(kr.is_empty());
+        assert_eq!(kr.len(), 0);
+        assert!(kr.private_key("").is_none());
+        assert!(kr.private_key("not here").is_none());
+        assert!(kr.public_key("").is_none());
+        assert!(kr.public_key("nor here").is_none());
+    }
+
+    mod new_key {
+        use super::*;
+
+        #[wasm_bindgen_test]
+        fn it_adds_a_new_random_keypair() {
+            let mut kr = KeyRing::new();
+            assert!(kr.public_key("a").is_none());
+            assert!(kr.public_key("b").is_none());
+
+            assert_eq!(kr.new_key("a".into()), 1);
+            assert_eq!(kr.new_key("b".into()), 2);
+            assert_eq!(kr.len(), 2);
+
+            let sk_a = kr.expect_private_key("a");
+            let pk_a = kr.expect_public_key("a");
+            assert_eq!(*pk_a, RistrettoPublicKey::from_secret_key(&sk_a));
+
+            let sk_b = kr.expect_private_key("b");
+            assert_ne!(sk_a, sk_b);
+        }
+    }
+
+    mod sign {
+        use super::*;
+
+        fn sign(kr: &KeyRing, id: &str) -> Result<RistrettoSchnorr, String> {
+            let result = kr.sign(id, SAMPLE_CHALLENGE).into_serde::<SignResult>().unwrap();
+            if !result.error.is_empty() {
+                return Err(result.error);
+            }
+            let p_r = RistrettoPublicKey::from_hex(&result.public_nonce.unwrap()).unwrap();
+            let s = RistrettoSecretKey::from_hex(&result.signature.unwrap()).unwrap();
+            Ok(RistrettoSchnorr::new(p_r, s))
+        }
+
+        #[wasm_bindgen_test]
+        fn it_fails_if_key_doesnt_exist() {
+            let kr = new_keyring();
+            sign(&kr, "doesn-exist").unwrap_err();
+        }
+
+        #[wasm_bindgen_test]
+        fn it_produces_a_valid_signature() {
+            let kr = new_keyring();
+            let sig = sign(&kr, "a").unwrap();
+            let pk = kr.expect_public_key("a");
+            assert!(sig.verify_challenge(&pk, &hash(SAMPLE_CHALLENGE)));
+        }
+    }
+
+    mod opens {
+        use super::*;
+
+        #[wasm_bindgen_test]
+        fn it_returns_false_if_key_doesnt_exist() {
+            let kr = new_keyring();
+            assert_eq!(kr.opens("doesnt-exist", 0, ""), false);
+            assert_eq!(kr.opens("doesnt-exist", u64::MAX, ""), false);
+            let c = create_commitment(kr.expect_private_key("a"), 0);
+            assert_eq!(kr.opens("doesnt-exist", 0, &c.to_hex()), false);
+        }
+
+        #[wasm_bindgen_test]
+        fn it_returns_false_does_not_open_commitment() {
+            let kr = new_keyring();
+            let c = create_commitment(&RistrettoSecretKey::random(&mut OsRng), 123);
+            assert_eq!(kr.opens("a", 123, &c.to_hex()), false);
+
+            let c = create_commitment(kr.expect_private_key("a"), 123);
+            assert_eq!(kr.opens("a", 321, &c.to_hex()), false);
+
+            let c = create_commitment(kr.expect_private_key("a"), 123);
+            assert_eq!(kr.opens("b", 123, &c.to_hex()), false);
+        }
+
+        #[wasm_bindgen_test]
+        fn it_returns_true_if_commitment_opened() {
+            let kr = new_keyring();
+            let c = create_commitment(kr.expect_private_key("a"), 123);
+            assert_eq!(kr.opens("a", 123, &c.to_hex()), true);
+        }
+    }
+
+    mod commit {
+        use super::*;
+
+        fn commit(kr: &KeyRing, id: &str, value: u64) -> Result<PedersenCommitment, String> {
+            let result = kr.commit(id, value).into_serde::<CommitmentResult>().unwrap();
+            if !result.error.is_empty() {
+                return Err(result.error);
+            }
+            Ok(PedersenCommitment::from_hex(&result.commitment.unwrap()).unwrap())
+        }
+
+        #[wasm_bindgen_test]
+        fn it_fails_if_key_doesnt_exist() {
+            let kr = new_keyring();
+            commit(&kr, "doesnt-exist", 0).unwrap_err();
+        }
+
+        #[wasm_bindgen_test]
+        fn it_produces_a_commitment_that_can_be_opened() {
+            let kr = new_keyring();
+            let c = commit(&kr, "a", 0).unwrap();
+            assert!(kr.opens("a", 0, &c.to_hex()));
+            let c = commit(&kr, "a", u64::MAX).unwrap();
+            assert!(kr.opens("a", u64::MAX, &c.to_hex()));
+        }
+
+        #[wasm_bindgen_test]
+        fn it_produces_a_valid_commitment() {
+            let kr = new_keyring();
+            let expected_commit = create_commitment(kr.expect_private_key("a"), 123);
+            let c = commit(&kr, "a", 123).unwrap();
+            assert_eq!(c, expected_commit);
+        }
+    }
+}

--- a/wasm-demo.js
+++ b/wasm-demo.js
@@ -100,12 +100,14 @@ const proof = rp.create_proof(k, v);
 if (proof.error) {
     console.log(`Range proof error: ${proof.error}`);
 } else {
-    console.log(`Range proof: ${proof.proof}`);
-    // let is_valid = rp.verify(k, v, proof.proof);
-    // console.log("Should be valid:", is_valid);
-    //
-    // is_valid = rp.verify(k, BigInt(46), proof.proof);
-    // console.log("Should not be valid:", is_valid);
+    console.log(`Range proof: ${commitment.commitment} ${proof.proof}`);
+    let is_valid = rp.verify(commitment.commitment, proof.proof);
+    console.log("Should be valid:", is_valid);
+
+
+    let {commitment: bad_commit} = tari_crypto.commit(k, BigInt(46));
+    is_valid = rp.verify(bad_commit, proof.proof);
+    console.log("Should not be valid:", is_valid);
 
 }
 rp.free();

--- a/wasm.sh
+++ b/wasm.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+CHOICE="${1:-""}"
+shift || true
+
+if ! [ -x "$(command -v wasm-pack)" ]; then
+  echo "Please install wasm-pack to run this script. https://rustwasm.github.io/wasm-pack/"
+  exit 1
+fi
+
+if ! [ -x "$(command -v node)" ]; then
+  echo "Please install node to run this script."
+  exit 1
+fi
+
+case "$CHOICE" in
+  test) wasm-pack test --node --features wasm "$@"
+    ;;
+  build) wasm-pack build --target nodejs --out-dir tari_js/ -- --features wasm "$@"
+    ;;
+  "")
+    echo "USAGE: $0 (test|build)"
+  ;;
+  *)
+    echo "Invalid option '$CHOICE'"
+    echo "USAGE: $0 (test|build)"
+  ;;
+esac
+


### PR DESCRIPTION
- Add extensive unit test coverage for WASM libs
- Use optional `getrandom` dependency for the `wasm` feature and turn on
  `getrandom/js`
  (https://docs.rs/getrandom/0.2.3/getrandom/#unsupported-targets)
- Re-add rangeproof verify WASM (works with `wasm-demo`)
- Add `wasm_bindgen_test` dev-dependency
- Add `wasm.sh` script to run tests (`./wasm.sh test`) and builds (`./wasm.sh build`)