### PR TITLE
fix: reduce memory allocation on execution_stack and scripts

### DIFF
--- a/src/script/op_codes.rs
+++ b/src/script/op_codes.rs
@@ -270,7 +270,7 @@ pub enum Opcode {
 
 impl Opcode {
     pub fn parse(bytes: &[u8]) -> Result<Vec<Opcode>, ScriptError> {
-        let mut script = Vec::with_capacity(512);
+        let mut script = Vec::new();
         let mut bytes_copy = bytes;
 
         while !bytes_copy.is_empty() {

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -243,14 +243,14 @@ impl ExecutionStack {
 
     /// Return a binary array representation of the input stack
     pub fn as_bytes(&self) -> Vec<u8> {
-        self.items.iter().fold(Vec::with_capacity(512), |mut bytes, item| {
+        self.items.iter().fold(Vec::new(), |mut bytes, item| {
             item.to_bytes(&mut bytes);
             bytes
         })
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ScriptError> {
-        let mut items = Vec::with_capacity(512);
+        let mut items = Vec::new();
         let mut byte_str = bytes;
         while !byte_str.is_empty() {
             match StackItem::read_next(byte_str) {

--- a/src/script/tari_script.rs
+++ b/src/script/tari_script.rs
@@ -110,7 +110,7 @@ impl TariScript {
     }
 
     pub fn as_bytes(&self) -> Vec<u8> {
-        self.script.iter().fold(Vec::with_capacity(512), |mut bytes, op| {
+        self.script.iter().fold(Vec::new(), |mut bytes, op| {
             op.to_bytes(&mut bytes);
             bytes
         })


### PR DESCRIPTION
This PR is to combat a memory leak for the console wallet in Ubuntu 18.04 and 20.04. 

Instrumenting the console wallet with https://docs.rs/dhat/0.2.2/dhat/ and testing with `valgrind --tool=dhat` highlighted `Script` and `ExecutionStack` as the culprits. Pre-allocation of `Script` and `ExecutionStack` vectors (`Vec::with_capacity(512)`) resulted in memory usage of 12GB vs. 4.4GB when using `Vec::new()` for a large wallet.

View with https://nnethercote.github.io/dh_view/dh_view.html

**With this PR**
[dhat-heap.json.30285_vec_new.log](https://github.com/tari-project/tari-crypto/files/7167562/dhat-heap.json.30285_vec_new.log)

**Pre this PR**
[dhat-heap.json.19190.log](https://github.com/tari-project/tari-crypto/files/7167554/dhat-heap.json.19190.log)
