### PR TITLE
Don't do source code coverage on PRs

### DIFF
--- a/.github/workflows/source-cov.yml
+++ b/.github/workflows/source-cov.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened ]
 jobs:
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Coverage GA is broken for PRs
- It's not necessary to run code coverage for every PR