### PR TITLE
fix: ensure ExecutionStack cannot exceed MAX_STACK_SIZE

### DIFF
--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -26,7 +26,7 @@ use tari_utilities::{
     hex::{from_hex, to_hex, Hex, HexError},
     ByteArray,
 };
-pub const MAX_STACK_SIZE: usize = 256;
+pub const MAX_STACK_SIZE: usize = 255;
 
 #[macro_export]
 macro_rules! inputs {
@@ -250,18 +250,18 @@ impl ExecutionStack {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ScriptError> {
-        let mut items = Vec::new();
+        let mut stack = ExecutionStack { items: Vec::new() };
         let mut byte_str = bytes;
         while !byte_str.is_empty() {
             match StackItem::read_next(byte_str) {
                 Some((item, b)) => {
-                    items.push(item);
+                    stack.push(item)?;
                     byte_str = b;
                 },
                 None => return Err(ScriptError::InvalidInput),
             }
         }
-        Ok(ExecutionStack { items })
+        Ok(stack)
     }
 
     /// Pushes the item onto the top of the stack. This function will only error if the new stack size exceeds the

--- a/src/script/tari_script.rs
+++ b/src/script/tari_script.rs
@@ -99,6 +99,11 @@ impl TariScript {
         }
     }
 
+    /// Returns the number of script op codes
+    pub fn size(&self) -> usize {
+        self.script.len()
+    }
+
     fn should_execute(&self, opcode: &Opcode, state: &ExecutionState) -> Result<bool, ScriptError> {
         use Opcode::*;
         match opcode {


### PR DESCRIPTION
- Check that ExecutionStack does not exceed MAX_STACK_SIZE (255) when decoding from bytes
- Add `size()` to tari script ~~required to limit the maximum number of script elements in transaction and block validation~~ 