### PR TITLE
[wip] refactor!: separate pub keys and signatures into compressed and noncompressed traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.11.2"
 edition = "2018"
 
 [dependencies]
-tari_utilities = "^0.3"
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities", branch="main"}
 base64 = "0.10.1"
 digest = "0.9.0"
 rand = { version = "0.8", default-features = false }

--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -30,11 +30,20 @@ use tari_crypto::{
     ristretto::{
         dalek_range_proof::DalekRangeProofService,
         pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        CompressedRistrettoPublicKey,
+        RistrettoPublicKey,
         RistrettoSecretKey,
     },
 };
 
-fn setup(n: usize) -> (DalekRangeProofService, RistrettoSecretKey, u64, PedersenCommitment) {
+fn setup(
+    n: usize,
+) -> (
+    DalekRangeProofService,
+    RistrettoSecretKey,
+    u64,
+    CompressedRistrettoPublicKey,
+) {
     let mut rng = thread_rng();
     let base = PedersenCommitmentFactory::default();
     let prover = DalekRangeProofService::new(n, &base).unwrap();
@@ -42,7 +51,7 @@ fn setup(n: usize) -> (DalekRangeProofService, RistrettoSecretKey, u64, Pedersen
     let n_max = 1u64 << (n as u64 - 1);
     let v = rng.gen_range(1..n_max);
     let c = base.commit_value(&k, v);
-    (prover, k, v, c)
+    (prover, k, v, c.as_public_key().compress())
 }
 
 pub fn generate_rangeproof(c: &mut Criterion) {

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -61,35 +61,6 @@ where P: PublicKey
     }
 }
 
-impl<P> ByteArray for HomomorphicCommitment<P>
-where P: PublicKey
-{
-    fn from_bytes(bytes: &[u8]) -> Result<Self, ByteArrayError> {
-        let p = P::from_bytes(bytes)?;
-        Ok(Self(p))
-    }
-
-    fn as_bytes(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl<P> PartialOrd for HomomorphicCommitment<P>
-where P: PublicKey
-{
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.0.cmp(&other.0))
-    }
-}
-
-impl<P> Ord for HomomorphicCommitment<P>
-where P: PublicKey
-{
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.cmp(&other.0)
-    }
-}
-
 /// Add two commitments together. Note! There is no check that the bases are equal.
 impl<'b, P> Add for &'b HomomorphicCommitment<P>
 where
@@ -141,12 +112,6 @@ where
     fn mul(self, rhs: &'b K) -> HomomorphicCommitment<P> {
         let p = rhs * &self.0;
         HomomorphicCommitment::<P>::from_public_key(&p)
-    }
-}
-
-impl<P: PublicKey> Hash for HomomorphicCommitment<P> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(self.as_bytes())
     }
 }
 

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     commitment::HomomorphicCommitment,
-    keys::{PublicKey, SecretKey},
+    keys::{CompressedPublicKey, PublicKey, SecretKey},
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -49,6 +49,7 @@ pub trait RangeProofService {
     type P: Sized;
     type K: SecretKey;
     type PK: PublicKey<K = Self::K>;
+    type CPK: CompressedPublicKey<Self::PK>;
 
     /// Construct a new range proof for the given secret key and value. The resulting proof will be sufficient
     /// evidence that the prover knows the secret key and value, and that the value lies in the range determined by
@@ -57,7 +58,7 @@ pub trait RangeProofService {
 
     /// Verify the range proof against the given commitment. If this function returns true, it attests to the
     /// commitment having a value in the range [0; 2^64-1] and that the prover knew both the value and private key.
-    fn verify(&self, proof: &Self::P, commitment: &HomomorphicCommitment<Self::PK>) -> bool;
+    fn verify(&self, proof: &Self::P, commitment: &Self::CPK) -> bool;
 
     /// Return the maximum range of the range proof as a power of 2. i.e. if the maximum range is 2^64, this function
     /// returns 64.
@@ -79,9 +80,9 @@ pub trait RangeProofService {
     fn rewind_proof_value_only(
         &self,
         proof: &Self::P,
-        commitment: &HomomorphicCommitment<Self::PK>,
-        rewind_public_key: &Self::PK,
-        rewind_blinding_public_key: &Self::PK,
+        commitment: &Self::CPK,
+        rewind_public_key: &Self::CPK,
+        rewind_blinding_public_key: &Self::CPK,
     ) -> Result<RewindResult, RangeProofError>;
 
     /// Fully rewind a rewindable range proof to reveal the committed value, blinding factor and the 19 byte proof
@@ -89,7 +90,7 @@ pub trait RangeProofService {
     fn rewind_proof_commitment_data(
         &self,
         proof: &Self::P,
-        commitment: &HomomorphicCommitment<Self::PK>,
+        commitment: &Self::CPK,
         rewind_key: &Self::K,
         rewind_blinding_key: &Self::K,
     ) -> Result<FullRewindResult<Self::K>, RangeProofError>;

--- a/src/ristretto/mod.rs
+++ b/src/ristretto/mod.rs
@@ -33,9 +33,9 @@ pub mod utils;
 
 // Re-export
 pub use self::{
-    ristretto_com_sig::RistrettoComSig,
-    ristretto_keys::{RistrettoPublicKey, RistrettoSecretKey},
-    ristretto_sig::RistrettoSchnorr,
+    ristretto_com_sig::{CompressedRistrettoComSig, RistrettoComSig},
+    ristretto_keys::{CompressedRistrettoPublicKey, RistrettoPublicKey, RistrettoSecretKey},
+    ristretto_sig::{CompressedRistrettoSchnorr, RistrettoSchnorr},
 };
 
 // test modules

--- a/src/ristretto/pedersen.rs
+++ b/src/ristretto/pedersen.rs
@@ -65,13 +65,13 @@ impl HomomorphicCommitmentFactory for PedersenCommitmentFactory {
 
     fn commit(&self, k: &RistrettoSecretKey, v: &RistrettoSecretKey) -> PedersenCommitment {
         let c = RistrettoPoint::multiscalar_mul(&[v.0, k.0], &[self.H, self.G]);
-        HomomorphicCommitment(RistrettoPublicKey::new_from_pk(c))
+        HomomorphicCommitment(RistrettoPublicKey::new(c))
     }
 
     fn zero(&self) -> PedersenCommitment {
         let zero = Scalar::zero();
         let c = RistrettoPoint::multiscalar_mul(&[zero, zero], &[self.H, self.G]);
-        HomomorphicCommitment(RistrettoPublicKey::new_from_pk(c))
+        HomomorphicCommitment(RistrettoPublicKey::new(c))
     }
 
     fn open(&self, k: &RistrettoSecretKey, v: &RistrettoSecretKey, commitment: &PedersenCommitment) -> bool {
@@ -100,7 +100,7 @@ where T: Borrow<PedersenCommitment>
             let commitment = c.borrow();
             total += (commitment.0).point
         }
-        let sum = RistrettoPublicKey::new_from_pk(total);
+        let sum = RistrettoPublicKey::new(total);
         HomomorphicCommitment(sum)
     }
 }

--- a/src/ristretto/ristretto_sig.rs
+++ b/src/ristretto/ristretto_sig.rs
@@ -21,8 +21,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
-    signatures::SchnorrSignature,
+    keys::CompressedPublicKey,
+    ristretto::{ristretto_keys::CompressedRistrettoPublicKey, RistrettoPublicKey, RistrettoSecretKey},
+    signatures::{CompressedSchnorrSignature, SchnorrSignature},
 };
 
 /// # A Schnorr signature implementation on Ristretto
@@ -97,6 +98,22 @@ use crate::{
 /// assert!(sig.verify_challenge(&P, &e));
 /// ```
 pub type RistrettoSchnorr = SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey>;
+pub type CompressedRistrettoSchnorr =
+    CompressedSchnorrSignature<CompressedRistrettoPublicKey, RistrettoPublicKey, RistrettoSecretKey>;
+
+impl CompressedSchnorrSignature<CompressedRistrettoPublicKey, RistrettoPublicKey, RistrettoSecretKey> {
+    pub fn decompress(&self) -> Option<RistrettoSchnorr> {
+        self.get_public_nonce()
+            .decompress()
+            .map(|pn| RistrettoSchnorr::new(pn, self.get_signature().clone()))
+    }
+}
+
+impl RistrettoSchnorr {
+    pub fn compress(&self) -> CompressedRistrettoSchnorr {
+        CompressedRistrettoSchnorr::new(self.get_public_nonce().compress(), self.get_signature().clone())
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/src/ristretto/utils.rs
+++ b/src/ristretto/utils.rs
@@ -45,7 +45,7 @@ pub fn sign<D: Digest>(
     let mut rng = rand::thread_rng();
     let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut rng);
     let message = D::new()
-        .chain(public_nonce.as_bytes())
+        .chain(public_nonce.compress().as_bytes())
         .chain(message)
         .finalize()
         .to_vec();

--- a/src/script/script_context.rs
+++ b/src/script/script_context.rs
@@ -15,7 +15,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{ristretto::pedersen::PedersenCommitment, script::op_codes::HashValue};
+use crate::{
+    ristretto::{pedersen::PedersenCommitment, ristretto_keys::CompressedRistrettoPublicKey},
+    script::op_codes::HashValue,
+};
 
 /// Contextual data for use in Tari scripts. The context will typically be unambiguously and deterministically
 /// populated by nodes that are executing the script.
@@ -26,11 +29,11 @@ pub struct ScriptContext {
     /// The hash of the previous block's hash
     prev_block_hash: HashValue,
     /// The commitment of the UTXO that is attached to this script
-    commitment: PedersenCommitment,
+    commitment: CompressedRistrettoPublicKey,
 }
 
 impl ScriptContext {
-    pub fn new(height: u64, prev_hash: &HashValue, com: &PedersenCommitment) -> Self {
+    pub fn new(height: u64, prev_hash: &HashValue, com: &CompressedRistrettoPublicKey) -> Self {
         ScriptContext {
             block_height: height,
             prev_block_hash: *prev_hash,
@@ -47,7 +50,7 @@ impl ScriptContext {
         &self.prev_block_hash
     }
 
-    pub fn commitment(&self) -> &PedersenCommitment {
+    pub fn commitment(&self) -> &CompressedRistrettoPublicKey {
         &self.commitment
     }
 }

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -18,7 +18,14 @@
 use std::convert::TryFrom;
 
 use crate::{
-    ristretto::{pedersen::PedersenCommitment, RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
+    ristretto::{
+        pedersen::PedersenCommitment,
+        ristretto_keys::CompressedRistrettoPublicKey,
+        ristretto_sig::CompressedRistrettoSchnorr,
+        RistrettoPublicKey,
+        RistrettoSchnorr,
+        RistrettoSecretKey,
+    },
     script::{error::ScriptError, op_codes::HashValue},
 };
 use serde::{Deserialize, Serialize};
@@ -26,6 +33,7 @@ use tari_utilities::{
     hex::{from_hex, to_hex, Hex, HexError},
     ByteArray,
 };
+
 pub const MAX_STACK_SIZE: usize = 256;
 
 #[macro_export]
@@ -58,9 +66,9 @@ pub const TYPE_SIG: u8 = 5;
 pub enum StackItem {
     Number(i64),
     Hash(HashValue),
-    Commitment(PedersenCommitment),
-    PublicKey(RistrettoPublicKey),
-    Signature(RistrettoSchnorr),
+    Commitment(CompressedRistrettoPublicKey),
+    PublicKey(CompressedRistrettoPublicKey),
+    Signature(CompressedRistrettoSchnorr),
 }
 
 impl StackItem {
@@ -130,7 +138,7 @@ impl StackItem {
         if b.len() < 32 {
             return None;
         }
-        let c = PedersenCommitment::from_bytes(&b[..32]).ok()?;
+        let c = CompressedRistrettoPublicKey::from_bytes(&b[..32]).ok()?;
         Some((StackItem::Commitment(c), &b[32..]))
     }
 
@@ -138,7 +146,7 @@ impl StackItem {
         if b.len() < 32 {
             return None;
         }
-        let p = RistrettoPublicKey::from_bytes(&b[..32]).ok()?;
+        let p = CompressedRistrettoPublicKey::from_bytes(&b[..32]).ok()?;
         Some((StackItem::PublicKey(p), &b[32..]))
     }
 
@@ -146,17 +154,17 @@ impl StackItem {
         if b.len() < 64 {
             return None;
         }
-        let r = RistrettoPublicKey::from_bytes(&b[..32]).ok()?;
+        let r = CompressedRistrettoPublicKey::from_bytes(&b[..32]).ok()?;
         let s = RistrettoSecretKey::from_bytes(&b[32..64]).ok()?;
-        let sig = RistrettoSchnorr::new(r, s);
+        let sig = CompressedRistrettoSchnorr::new(r, s);
         Some((StackItem::Signature(sig), &b[64..]))
     }
 }
 
 stack_item_from!(i64 => Number);
-stack_item_from!(PedersenCommitment => Commitment);
-stack_item_from!(RistrettoPublicKey => PublicKey);
-stack_item_from!(RistrettoSchnorr => Signature);
+// stack_item_from!(CompressedRistrettoPublicKey => Commitment);
+stack_item_from!(CompressedRistrettoPublicKey => PublicKey);
+stack_item_from!(CompressedRistrettoSchnorr => Signature);
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionStack {


### PR DESCRIPTION
Compressing and decompressing Ristretto points can take a long time and was a large portion of the CPU time in the Tari project. 

This PR splits the traits into two for each of PublicKey, Signature, and CommitmentSignature.

The original trait no longer implements `ByteArray`, `Serialize` or `Deserialize` and must be compressed before serializing. 

Probably the biggest gainer in the `tari-crypto` crate itself is that points are no longer compressed when `Adding` or `Multiplying`.

Below is one of the benchmarks showing the new time for verifying signatures (red) against the old (blue) 
![image](https://user-images.githubusercontent.com/4200336/142606315-17ea8ead-04b9-45d6-956e-bb38a6c4792b.png)
