### PR TITLE
perf: lazily compress RistrettoPublicKey

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          # TODO: re-add all features once https://github.com/rust-lang/packed_simd/pull/341 is used by dalek
+          # args: --all-features
+          args: --features wasm --features ffi --features no_cc
       - name: test/release all features
         if: ${{ matrix.rust != 'stable' }}
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --all-features
+          # TODO: re-add all features once https://github.com/rust-lang/packed_simd/pull/341 is used by dalek
+          # args: --release --all-features
+          args: --release --features wasm --features ffi --features no_cc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           command: test
           # TODO: re-add all features once https://github.com/rust-lang/packed_simd/pull/341 is used by dalek
           # args: --all-features
-          args: --features wasm --features ffi --features no_cc
+          args: --features wasm --features ffi
       - name: test/release all features
         if: ${{ matrix.rust != 'stable' }}
         uses: actions-rs/cargo@v1
@@ -44,4 +44,4 @@ jobs:
           command: test
           # TODO: re-add all features once https://github.com/rust-lang/packed_simd/pull/341 is used by dalek
           # args: --release --all-features
-          args: --release --features wasm --features ffi --features no_cc
+          args: --release --features wasm --features ffi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,21 +12,23 @@ edition = "2018"
 
 [dependencies]
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", branch = "main" }
+
 base64 = "0.10.1"
-digest = "0.9.0"
-rand = { version = "0.8", default-features = false }
-getrandom = { version = "0.2.3", default-features = false, optional = true }
-curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["u64_backend", "serde", "alloc"] }
-bulletproofs = { version = "4.1", package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", branch = "main" } # todo: update when 4.1 pushed to crates.io
-merlin = { version = "3", default-features = false }
-sha2 = "0.9.5"
-sha3 = "0.9"
-thiserror = "1.0.20"
 blake2 = "0.9.1"
+bulletproofs = { version = "4.1", package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", branch = "main" } # todo: update when 4.1 pushed to crates.io
+curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["u64_backend", "serde", "alloc"] }
+digest = "0.9.0"
+getrandom = { version = "0.2.3", default-features = false, optional = true }
+lazy_static = "1.3.0"
+merlin = { version = "3", default-features = false }
+once_cell = "1.8.0"
+rand = { version = "0.8", default-features = false }
 rmp-serde = "0.13.7"
 serde = "1.0.89"
 serde_json = "1.0"
-lazy_static = "1.3.0"
+sha2 = "0.9.5"
+sha3 = "0.9"
+thiserror = "1.0.20"
 wasm-bindgen = { version = "^0.2", features = ["serde-serialize"], optional = true }
 zeroize = { version = "1.3.0", default-features = false, features = ["alloc"] }
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ffi: target/debug/libtari_crypto.a
 ffi-release: target/release/libtari_crypto.a
 
 wasm:
-	wasm-pack build . -- --features "wasm, no_cc_nightly"
+	wasm-pack build . -- --features "wasm"
 
 wasm-node:
-	wasm-pack build --target nodejs -d tari_js . -- --features "wasm, no_cc_nightly"
+	wasm-pack build --target nodejs -d tari_js . -- --features "wasm"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ To generate a module for use in node.js, use this command:
 
     $ wasm-pack build --target nodejs -d tari_js . -- --features "wasm"
 
-If you receive compoiler errors related to `clear_on_drop`, then add the `no_cc` or `no_cc_nightly` feature flags.
-    
 Note: Node v10+ is needed for the WASM 
 
 ## Example (Node.js)

--- a/src/ristretto/dalek_range_proof.rs
+++ b/src/ristretto/dalek_range_proof.rs
@@ -95,7 +95,7 @@ impl RangeProofService for DalekRangeProofService {
         let rp = rp.unwrap();
         let mut pt = Transcript::new(b"tari");
         let c = &commitment.0;
-        rp.verify_single(&self.bp_gens, &self.pc_gens, &mut pt, &c.compressed, self.range)
+        rp.verify_single(&self.bp_gens, &self.pc_gens, &mut pt, c.compressed(), self.range)
             .is_ok()
     }
 
@@ -145,16 +145,16 @@ impl RangeProofService for DalekRangeProofService {
 
         let mut pt = Transcript::new(b"tari");
         let rewind_nonce_1 =
-            get_rewind_nonce_from_pub_key(&rewind_public_key.compressed, &commitment.as_public_key().compressed);
+            get_rewind_nonce_from_pub_key(rewind_public_key.compressed(), commitment.as_public_key().compressed());
         let rewind_nonce_2 = get_rewind_nonce_from_pub_key(
-            &rewind_blinding_public_key.compressed,
-            &commitment.as_public_key().compressed,
+            rewind_blinding_public_key.compressed(),
+            commitment.as_public_key().compressed(),
         );
         let (confidential_value, proof_message) = rp
             .rewind_single_get_value_only(
                 &self.bp_gens,
                 &mut pt,
-                &commitment.as_public_key().compressed,
+                commitment.as_public_key().compressed(),
                 self.range,
                 &rewind_nonce_1,
                 &rewind_nonce_2,
@@ -181,20 +181,20 @@ impl RangeProofService for DalekRangeProofService {
         let rewind_public_key = RistrettoPublicKey::from_secret_key(rewind_key);
         let rewind_blinding_public_key = RistrettoPublicKey::from_secret_key(rewind_blinding_key);
         let rewind_nonce_1 =
-            get_rewind_nonce_from_pub_key(&rewind_public_key.compressed, &commitment.as_public_key().compressed);
+            get_rewind_nonce_from_pub_key(rewind_public_key.compressed(), commitment.as_public_key().compressed());
         let rewind_nonce_2 = get_rewind_nonce_from_pub_key(
-            &rewind_blinding_public_key.compressed,
-            &commitment.as_public_key().compressed,
+            rewind_blinding_public_key.compressed(),
+            commitment.as_public_key().compressed(),
         );
-        let blinding_nonce_1 = get_secret_nonce_from_pvt_key(&rewind_key.0, &commitment.as_public_key().compressed);
+        let blinding_nonce_1 = get_secret_nonce_from_pvt_key(&rewind_key.0, commitment.as_public_key().compressed());
         let blinding_nonce_2 =
-            get_secret_nonce_from_pvt_key(&rewind_blinding_key.0, &commitment.as_public_key().compressed);
+            get_secret_nonce_from_pvt_key(&rewind_blinding_key.0, commitment.as_public_key().compressed());
         let (confidential_value, blinding_factor, proof_message) = rp
             .rewind_single_get_commitment_data(
                 &self.bp_gens,
                 &self.pc_gens,
                 &mut pt,
-                &commitment.as_public_key().compressed,
+                commitment.as_public_key().compressed(),
                 self.range,
                 &rewind_nonce_1,
                 &rewind_nonce_2,

--- a/src/ristretto/pedersen.rs
+++ b/src/ristretto/pedersen.rs
@@ -98,7 +98,7 @@ where T: Borrow<PedersenCommitment>
         let mut total = RistrettoPoint::default();
         for c in iter {
             let commitment = c.borrow();
-            total += (commitment.0).point
+            total += RistrettoPoint::from(&commitment.0);
         }
         let sum = RistrettoPublicKey::new_from_pk(total);
         HomomorphicCommitment(sum)


### PR DESCRIPTION
Implement lazy compression for RistrettoPublicKey using thread-safe [`OnceCell`](https://docs.rs/once_cell/latest/once_cell/index.html) (currently unstable in std) 

![image](https://user-images.githubusercontent.com/1057902/148182436-1a29d610-4727-49be-9339-f83b53b568ae.png)

Red is on current main branch, blue are the changes in the PR

- Minor optimisation for lexicographical public key ordering: using reference to the underlying compressed array rather than copying the array onto the stack and then creating a reference 