### PR TITLE
refactor: replace clear_on_drop with zeroize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,8 @@ base64 = "0.10.1"
 digest = "0.9.0"
 rand = { version = "0.8", default-features = false }
 getrandom = { version = "0.2.3", default-features = false, optional = true }
-clear_on_drop = "=0.2.4"
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["u64_backend", "serde", "alloc"] }
-bulletproofs = { version = "4.1", package="tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", branch = "main" } # todo: update when 4.1 pushed to crates.io
+bulletproofs = { version = "4.1", package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", branch = "main" } # todo: update when 4.1 pushed to crates.io
 merlin = { version = "3", default-features = false }
 sha2 = "0.9.5"
 sha3 = "0.9"
@@ -29,6 +28,7 @@ serde = "1.0.89"
 serde_json = "1.0"
 lazy_static = "1.3.0"
 wasm-bindgen = { version = "^0.2", features = ["serde-serialize"], optional = true }
+zeroize = { version = "1.3.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 criterion = "0.3.4"
@@ -40,14 +40,12 @@ wasm-bindgen-test = "0.3.24"
 cbindgen = "0.17.0"
 
 [features]
-default = ["no_cc"]
+default = []
 simd_backend = ["curve25519-dalek/simd_backend", "bulletproofs/simd_backend"]
 simd = ["simd_backend"]
 avx2 = ["simd_backend"] # deprecated alias for simd_backend
 wasm = ["wasm-bindgen", "getrandom/js"]
 ffi = []
-no_cc_nightly = ["clear_on_drop/nightly"]
-no_cc = ["clear_on_drop/no_cc"]
 
 [lib]
 # Disable benchmarks to allow Criterion to take over

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -23,7 +23,6 @@
 //! The Tari-compatible implementation of Ristretto based on the curve25519-dalek implementation
 use crate::keys::{DiffieHellmanSharedSecret, PublicKey, SecretKey};
 use blake2::Blake2b;
-use clear_on_drop::clear::Clear;
 use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_TABLE,
     ristretto::{CompressedRistretto, RistrettoPoint},
@@ -40,6 +39,7 @@ use std::{
     ops::{Add, Mul, Sub},
 };
 use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, ExtendBytes, Hashable};
+use zeroize::Zeroize;
 
 /// The [SecretKey](trait.SecretKey.html) implementation for [Ristretto](https://ristretto.group) is a thin wrapper
 /// around the Dalek [Scalar](struct.Scalar.html) type, representing a 256-bit integer (mod the group order).
@@ -79,12 +79,10 @@ impl SecretKey for RistrettoSecretKey {
     }
 }
 
-//----------------------------------    Ristretto Secret Key Default   -----------------------------------------------//
-
 /// Clear the secret key value in memory when it goes out of scope
 impl Drop for RistrettoSecretKey {
     fn drop(&mut self) {
-        self.0.clear();
+        self.0.zeroize()
     }
 }
 


### PR DESCRIPTION
Replaces unmaintained `clear_on_drop` crate with `zeroize` (used by `curve25519-dalek`)

EDIT: another approach could be to call `zeroize()` on the Scalar on `RistrettoSecretKey` drop since it doesn't add any extra data. But, looking into the zeroize code, it all boils down to the same thing.