### PR TITLE
chore: point tari_utilities to the git repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
         rust:
           - stable
           - nightly-2022-01-17
-          - nightly
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.12.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = "^0.3"
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", branch = "main" }
 base64 = "0.10.1"
 digest = "0.9.0"
 rand = { version = "0.8", default-features = false }


### PR DESCRIPTION
We want to be able to use the latest tari_utilities in the main Tari repo rather than having to push new versions to crates but `tari_crypto` re-exports the crates version.

So updating `tari-crypto` to point at the `tari_utilities` git repo too for faster iteration.