### PR TITLE
chore: adds clippy denys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
-extern crate serde;
-extern crate serde_json;
+#![cfg_attr(not(debug_assertions), deny(unused_variables))]
+#![cfg_attr(not(debug_assertions), deny(unused_imports))]
+#![cfg_attr(not(debug_assertions), deny(dead_code))]
+#![cfg_attr(not(debug_assertions), deny(unused_extern_crates))]
+#![deny(unused_must_use)]
+#![deny(unreachable_patterns)]
+#![deny(unknown_lints)]
 
 #[macro_use]
 extern crate lazy_static;
@@ -12,11 +17,8 @@ pub mod keys;
 #[cfg(feature = "musig")]
 pub mod musig;
 pub mod range_proof;
-pub mod signatures;
-
-// Implementations
-#[allow(clippy::op_ref)]
 pub mod ristretto;
+pub mod signatures;
 
 #[cfg(feature = "wasm")]
 pub mod wasm;

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -131,7 +131,7 @@ impl<'a, 'b> Mul<&'b RistrettoPublicKey> for &'a RistrettoSecretKey {
     type Output = RistrettoPublicKey;
 
     fn mul(self, rhs: &'b RistrettoPublicKey) -> RistrettoPublicKey {
-        let p = &self.0 * &rhs.point;
+        let p = self.0 * rhs.point;
         RistrettoPublicKey::new_from_pk(p)
     }
 }
@@ -140,7 +140,7 @@ impl<'a, 'b> Add<&'b RistrettoSecretKey> for &'a RistrettoSecretKey {
     type Output = RistrettoSecretKey;
 
     fn add(self, rhs: &'b RistrettoSecretKey) -> RistrettoSecretKey {
-        let k = &self.0 + &rhs.0;
+        let k = self.0 + rhs.0;
         RistrettoSecretKey(k)
     }
 }
@@ -149,7 +149,7 @@ impl<'a, 'b> Sub<&'b RistrettoSecretKey> for &'a RistrettoSecretKey {
     type Output = RistrettoSecretKey;
 
     fn sub(self, rhs: &'b RistrettoSecretKey) -> RistrettoSecretKey {
-        RistrettoSecretKey(&self.0 - &rhs.0)
+        RistrettoSecretKey(self.0 - rhs.0)
     }
 }
 
@@ -362,7 +362,7 @@ impl<'a, 'b> Add<&'b RistrettoPublicKey> for &'a RistrettoPublicKey {
     type Output = RistrettoPublicKey;
 
     fn add(self, rhs: &'b RistrettoPublicKey) -> RistrettoPublicKey {
-        let p_sum = &self.point + &rhs.point;
+        let p_sum = self.point + rhs.point;
         RistrettoPublicKey::new_from_pk(p_sum)
     }
 }
@@ -371,7 +371,7 @@ impl<'a, 'b> Sub<&'b RistrettoPublicKey> for &'a RistrettoPublicKey {
     type Output = RistrettoPublicKey;
 
     fn sub(self, rhs: &RistrettoPublicKey) -> RistrettoPublicKey {
-        let p_sum = &self.point - &rhs.point;
+        let p_sum = self.point - rhs.point;
         RistrettoPublicKey::new_from_pk(p_sum)
     }
 }
@@ -380,7 +380,7 @@ impl<'a, 'b> Mul<&'b RistrettoSecretKey> for &'a RistrettoPublicKey {
     type Output = RistrettoPublicKey;
 
     fn mul(self, rhs: &'b RistrettoSecretKey) -> RistrettoPublicKey {
-        let p = &rhs.0 * &self.point;
+        let p = rhs.0 * self.point;
         RistrettoPublicKey::new_from_pk(p)
     }
 }
@@ -389,7 +389,7 @@ impl<'a, 'b> Mul<&'b RistrettoSecretKey> for &'a RistrettoSecretKey {
     type Output = RistrettoSecretKey;
 
     fn mul(self, rhs: &'b RistrettoSecretKey) -> RistrettoSecretKey {
-        let p = &rhs.0 * &self.0;
+        let p = rhs.0 * self.0;
         RistrettoSecretKey(p)
     }
 }


### PR DESCRIPTION
- adds denys for unacceptable clippy errors in release mode
- remove unnecessary clippy allows
- remove extraneous references for RistrettoPoint math ops (`&self.0 + &other.0` desugars to `Add::add(&&self.0, &&other.0)`)