### PR TITLE
feat: use standard-version

### DIFF
--- a/scripts/bump-version
+++ b/scripts/bump-version
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+pushd `git rev-parse --show-toplevel` > /dev/null
+# See https://github.com/conventional-changelog/standard-version#cli-usage for usage
+npx standard-version "$@"
+popd > /dev/null

--- a/scripts/cargo-version-updater.js
+++ b/scripts/cargo-version-updater.js
@@ -1,0 +1,15 @@
+const VERSION_REGEXP = /^version\s*=\s*"([^"]+)"/m;
+
+const readVersion = function (contents) {
+    const matches = contents.match(VERSION_REGEXP);
+    if (!matches) {
+        throw new Error("Version key not found!");
+    }
+    return matches[1];
+}
+
+const writeVersion = function (contents, version) {
+    return contents.replace(VERSION_REGEXP, `version = "${version}"`);
+}
+
+module.exports = {readVersion, writeVersion};


### PR DESCRIPTION
Adds script using `standard-version` to bump versions in Cargo.toml and update changelog

## Usage

`./scripts/bump-version`

**prereleases**

`./scripts/bump-version --prerelease rc`

https://github.com/conventional-changelog/standard-version#cli-usage