### PR TITLE
chore: move old changelog from readme to changelog.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ This crate is part of the [Tari Cryptocurrency](https://tari.com) project.
 
 Major features of this library include:
 
-* Pedersen commitments
-* Schnorr Signatures
-* Generic Public and Secret Keys
-* [Musig!](https://blockstream.com/2018/01/23/musig-key-aggregation-schnorr-signatures/)
+- Pedersen commitments
+- Schnorr Signatures
+- Generic Public and Secret Keys
+- [Musig!](https://blockstream.com/2018/01/23/musig-key-aggregation-schnorr-signatures/)
 
 The `tari_crypto` crate makes heavy use of the excellent [Dalek](https://github.com/dalek-cryptography/curve25519-dalek)
 libraries. The default implementation for Tari ECC is the [Ristretto255 curve](https://ristretto.group).
 
 # Compiling to WebAssembly
+
 To build the WebAssembly module, the `wasm` feature must be enabled:
 
     $ wasm-pack build . -- --features "wasm"
@@ -25,7 +26,7 @@ To generate a module for use in node.js, use this command:
 
     $ wasm-pack build --target nodejs -d tari_js . -- --features "wasm"
 
-Note: Node v10+ is needed for the WASM 
+Note: Node v10+ is needed for the WASM
 
 ## Example (Node.js)
 
@@ -39,7 +40,7 @@ console.log(`${keys.len()} keys in ring`); // 2
 console.log("kA = ", keys.private_key("Alice"));
 console.log("PB = ", keys.public_key("Bob"));
 keys.free();
-````
+```
 
 # Benchmarks
 
@@ -52,43 +53,6 @@ The benchmarks use Criterion and will produce nice graphs (if you have gnuplot i
 To run the benchmarks with SIMD instructions:
 
     $ cargo bench --features "avx2"
-
-# Change log
-
-## v0.11.0
-
-* All dependencies to use the digest 0.9 traits and APIs.
-
-Clients of this generally only need to update the `result` method to
-`finalize`; and obviously make use of the v0.9 `digest::Digest` trait
-where necessary.
-
-As a result, the deprecated k12, sha3 and Blake3 objects have been removed.
-Methods and functins that need a hasher are all generic over `Digest`.
-
-We retain the convenience wrapper over `VarBlake2B` to produce 256 bit
-hashes and implement the necessary sub-traits to support `digest::Digest`.
-
-## v0.10.0
-
-* Support stable rust
-
-Updated dependencies such that Rust stable 1.53 is now supported.
-The optimised avx_2 option will NOT rust on stable because there's
-still an unstable feature on subtle-ng. BUT this feature is actually
-for doc generation and has been removed from Rust. As soon as subtle-ng
-merges https://github.com/dalek-cryptography/subtle/pull/85, avx2 will
-probably be supported on stable as well.
-
-## v0.2.0
-
-### General
-* WASM and crate version now match. Eliminate that confusion.
-
-### WASM module
-* Breaking change: `KeyRing.sign` doesn't take a nonce any more. It's not needed, and why risk someone re-using it?
-* New method: `key_utils.sign` to sign keys not in the key ring
-* New module: Commitments
 
 # Building the C FFI module
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,29 +1,62 @@
 # Changelog
 
-
 ### [0.12.2](https://github.com/tari-project/tari-crypto/compare/v0.12.1...v0.12.2) (2022-03-25)
-
 
 ### Bug Fixes
 
-* lock bulletproof repo to correct version ([4650715](https://github.com/tari-project/tari-crypto/commit/465071528e26f0913f19d4297f3c05b0b4f21e41))
+- lock bulletproof repo to correct version ([4650715](https://github.com/tari-project/tari-crypto/commit/465071528e26f0913f19d4297f3c05b0b4f21e41))
 
 ### [0.12.1](https://github.com/tari-project/tari-crypto/compare/v0.12.0...v0.12.1) (2022-03-14)
 
-
 ### Features
 
-* allow custom hash parameters to be specified ([#84](https://github.com/tari-project/tari-crypto/issues/84)) ([5b412d0](https://github.com/tari-project/tari-crypto/commit/5b412d04ebc9a0bb0149a7dbf5ebf3c6116261c3))
-
-
-### Bug Fixes
-
-* **ci:** fix invalid env syntax ([#79](https://github.com/tari-project/tari-crypto/issues/79)) ([053e64e](https://github.com/tari-project/tari-crypto/commit/053e64ea1eea16c582df8b506d024326e075b876))
-* code coverage only works on nightly ([#78](https://github.com/tari-project/tari-crypto/issues/78)) ([a3ceaa9](https://github.com/tari-project/tari-crypto/commit/a3ceaa9a72debf7428cce2618fe6828ad66ff0b9))
-* ensure ExecutionStack cannot exceed MAX_STACK_SIZE ([#65](https://github.com/tari-project/tari-crypto/issues/65)) ([1b74d94](https://github.com/tari-project/tari-crypto/commit/1b74d944218587dd0fa60bc75db2eca1d5d7057d))
-
-### [0.11.0](https://github.com/tari-project/tari-crypto/compare/v0.11.0...v0.10.0) (2021-09-06)
+- allow custom hash parameters to be specified ([#84](https://github.com/tari-project/tari-crypto/issues/84)) ([5b412d0](https://github.com/tari-project/tari-crypto/commit/5b412d04ebc9a0bb0149a7dbf5ebf3c6116261c3))
 
 ### Bug Fixes
 
-*   remove extra compress call during pubkey::deserialize ([#56](https://github.com/tari-project/tari-crypto/issues/56)) ([8864b5a2](https://github.com/tari-project/tari-crypto/commit/8864b5a20bd55c8e075be67b132daebe22762e0c))
+- **ci:** fix invalid env syntax ([#79](https://github.com/tari-project/tari-crypto/issues/79)) ([053e64e](https://github.com/tari-project/tari-crypto/commit/053e64ea1eea16c582df8b506d024326e075b876))
+- code coverage only works on nightly ([#78](https://github.com/tari-project/tari-crypto/issues/78)) ([a3ceaa9](https://github.com/tari-project/tari-crypto/commit/a3ceaa9a72debf7428cce2618fe6828ad66ff0b9))
+- ensure ExecutionStack cannot exceed MAX_STACK_SIZE ([#65](https://github.com/tari-project/tari-crypto/issues/65)) ([1b74d94](https://github.com/tari-project/tari-crypto/commit/1b74d944218587dd0fa60bc75db2eca1d5d7057d))
+
+### [0.11.0](https://github.com/tari-project/tari-crypto/compare/v0.10.0...v0.11.0) (2021-09-06)
+
+### General
+
+- All dependencies to use the digest 0.9 traits and APIs.
+
+Clients of this generally only need to update the `result` method to
+`finalize`; and obviously make use of the v0.9 `digest::Digest` trait
+where necessary.
+
+As a result, the deprecated k12, sha3 and Blake3 objects have been removed.
+Methods and functins that need a hasher are all generic over `Digest`.
+
+We retain the convenience wrapper over `VarBlake2B` to produce 256 bit
+hashes and implement the necessary sub-traits to support `digest::Digest`.
+
+### Bug Fixes
+
+- remove extra compress call during pubkey::deserialize ([#56](https://github.com/tari-project/tari-crypto/issues/56)) ([8864b5a2](https://github.com/tari-project/tari-crypto/commit/8864b5a20bd55c8e075be67b132daebe22762e0c))
+
+### [0.10.0](https://github.com/tari-project/tari-crypto/compare/v0.2.0...v0.10.0) (2021-07-05)
+
+- Support stable rust
+
+Updated dependencies such that Rust stable 1.53 is now supported.
+The optimised avx_2 option will NOT rust on stable because there's
+still an unstable feature on subtle-ng. BUT this feature is actually
+for doc generation and has been removed from Rust. As soon as subtle-ng
+merges https://github.com/dalek-cryptography/subtle/pull/85, avx2 will
+probably be supported on stable as well.
+
+### [0.2.0](https://github.com/tari-project/tari-crypto/compare/v0.2.0) (2020-02-07)
+
+### General
+
+- WASM and crate version now match. Eliminate that confusion.
+
+### WASM module
+
+- Breaking change: `KeyRing.sign` doesn't take a nonce any more. It's not needed, and why risk someone re-using it?
+- New method: `key_utils.sign` to sign keys not in the key ring
+- New module: Commitments


### PR DESCRIPTION
Moved the old changelog from `readme.md` to `changlelog.md`.
Prettier also applied some changes.