### PR TITLE
chore: upgrade tari_utilities to latest tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.12.5"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.3.1" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.0" }
 
 base64 = "0.10.1"
 blake2 = "0.9.1"

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -39,7 +39,7 @@ use curve25519_dalek::{
 use digest::Digest;
 use once_cell::sync::OnceCell;
 use rand::{CryptoRng, Rng};
-use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, ExtendBytes, Hashable};
+use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, Hashable};
 use zeroize::Zeroize;
 
 use crate::keys::{DiffieHellmanSharedSecret, PublicKey, SecretKey};
@@ -264,14 +264,6 @@ impl DiffieHellmanSharedSecret for RistrettoPublicKey {
 impl Hashable for RistrettoPublicKey {
     fn hash(&self) -> Vec<u8> {
         Blake2b::digest(self.as_bytes()).to_vec()
-    }
-}
-
-// Requires custom Extendbytes implementation for RistrettoPublicKey as CompressedRistretto doesnt implement this trait
-impl ExtendBytes for RistrettoPublicKey {
-    fn append_raw_bytes(&self, buf: &mut Vec<u8>) {
-        let bytes = self.as_bytes();
-        buf.extend_from_slice(bytes);
     }
 }
 


### PR DESCRIPTION
- updates tari_crypto to git tag v0.4.0
- remove deprecated ExtendBytes usage