### PR TITLE
chore: bump tari_utilities for the hidden type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.13.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.3" }
+tari_utilities = { git = "https://github.com/brianp/tari_utilities", branch = "hidden-type" }
 
 base64 = "0.10.1"
 blake2 = "0.9.1"


### PR DESCRIPTION
Description
---
Just a version bump to keep tari and tari-crypto on the same version of tari_utilities.

Motivation and Context
---
Just because i have to

How Has This Been Tested?
---
That tari still builds