### PR TITLE
feat: add extended ristretto commitment factory and pedersen generators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 base64 = "0.10.1"
 blake2 = "0.9.1"
 bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", tag = "v4.2.0" }
-bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", tag = "v0.0.1" }
+bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", tag = "v0.0.3" }
 curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2", default-features = false, features = ["serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 base64 = "0.10.1"
 blake2 = "0.9.1"
 bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", tag = "v4.2.0" }
-bulletproofs_plus = { path = "../bulletproofs-plus", package = "tari_bulletproofs_plus"}
+bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus"}
 curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2", default-features = false, features = ["serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 base64 = "0.10.1"
 blake2 = "0.9.1"
 bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", tag = "v4.2.0" }
-bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus"}
+bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", tag = "v0.0.1" }
 curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2", default-features = false, features = ["serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 base64 = "0.10.1"
 blake2 = "0.9.1"
 bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", tag = "v4.2.0" }
-bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", tag = "v0.0.3" }
 curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2", default-features = false, features = ["serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 base64 = "0.10.1"
 blake2 = "0.9.1"
 bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", tag = "v4.2.0" }
+bulletproofs_plus = { path = "../bulletproofs-plus", package = "tari_bulletproofs_plus"}
 curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2", default-features = false, features = ["serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }

--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -30,7 +30,7 @@ use tari_crypto::{
     range_proof::RangeProofService,
     ristretto::{
         dalek_range_proof::DalekRangeProofService,
-        pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
         RistrettoSecretKey,
     },
 };

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use tari_utilities::{ByteArray, ByteArrayError};
 
 use crate::{
-    errors::RangeProofError,
+    errors::CommitmentError,
     keys::{PublicKey, SecretKey},
 };
 
@@ -189,32 +189,32 @@ pub trait ExtendedHomomorphicCommitmentFactory {
 
     /// Create a new commitment with the blinding factor vector **k** and value _v_ provided. The implementing type will
     /// provide the base values
-    fn commit(
+    fn commit_extended(
         &self,
         k_vec: &[<Self::P as PublicKey>::K],
         v: &<Self::P as PublicKey>::K,
-    ) -> Result<HomomorphicCommitment<Self::P>, RangeProofError>;
+    ) -> Result<HomomorphicCommitment<Self::P>, CommitmentError>;
     /// Return an identity point for addition using the specified base points. This is a commitment to zero with a zero
     /// blinding factor vector on the base points
-    fn zero(&self) -> HomomorphicCommitment<Self::P>;
+    fn zero_extended(&self) -> HomomorphicCommitment<Self::P>;
     /// Test whether the given blinding factor vector **k** and value _v_ open the given commitment
-    fn open(
+    fn open_extended(
         &self,
         k_vec: &[<Self::P as PublicKey>::K],
         v: &<Self::P as PublicKey>::K,
         commitment: &HomomorphicCommitment<Self::P>,
-    ) -> Result<bool, RangeProofError>;
+    ) -> Result<bool, CommitmentError>;
     /// Create a commitment from a blinding factor vector **k** and an integer value
-    fn commit_value(
+    fn commit_value_extended(
         &self,
         k_vec: &[<Self::P as PublicKey>::K],
         value: u64,
-    ) -> Result<HomomorphicCommitment<Self::P>, RangeProofError>;
+    ) -> Result<HomomorphicCommitment<Self::P>, CommitmentError>;
     /// Test whether the given private keys and value open the given commitment
-    fn open_value(
+    fn open_value_extended(
         &self,
         k_vec: &[<Self::P as PublicKey>::K],
         v: u64,
         commitment: &HomomorphicCommitment<Self::P>,
-    ) -> Result<bool, RangeProofError>;
+    ) -> Result<bool, CommitmentError>;
 }

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -46,9 +46,9 @@ use crate::{
 /// The Homomorphic part means, more or less, that commitments follow some of the standard rules of
 /// arithmetic. Adding two commitments is the same as committing to the sum of their parts:
 /// $$ \begin{aligned}
-///   C_1 &= v_1.G + k_1.H \\\\
-///   C_2 &= v_2.G + k_2.H \\\\
-///   \therefore C_1 + C_2 &= (v_1 + v_2)G + (k_1 + k_2)H
+///   C_1 &= v_1.H + k_1.G \\\\
+///   C_2 &= v_2.H + k_2.G \\\\
+///   \therefore C_1 + C_2 &= (v_1 + v_2)H + (k_1 + k_2)G
 /// \end{aligned} $$
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct HomomorphicCommitment<P>(pub(crate) P);

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -165,20 +165,20 @@ impl<P: PublicKey> Eq for HomomorphicCommitment<P> {}
 pub trait HomomorphicCommitmentFactory {
     type P: PublicKey;
 
-    /// Create a new commitment with the blinding factor k and value v provided. The implementing type will provide the
-    /// base values
+    /// Create a new commitment with the blinding factor _k_ and value _v_ provided. The implementing type will provide
+    /// the base values
     fn commit(&self, k: &<Self::P as PublicKey>::K, v: &<Self::P as PublicKey>::K) -> HomomorphicCommitment<Self::P>;
     /// Return an identity point for addition using the specified base point. This is a commitment to zero with a zero
     /// blinding factor on the base point
     fn zero(&self) -> HomomorphicCommitment<Self::P>;
-    /// Test whether the given blinding factor k and value v open the given commitment
+    /// Test whether the given blinding factor _k_ and value _v_ open the given commitment
     fn open(
         &self,
         k: &<Self::P as PublicKey>::K,
         v: &<Self::P as PublicKey>::K,
         commitment: &HomomorphicCommitment<Self::P>,
     ) -> bool;
-    /// Create a commitment from a blinding factor k and an integer value
+    /// Create a commitment from a blinding factor _k_ and an integer value
     fn commit_value(&self, k: &<Self::P as PublicKey>::K, value: u64) -> HomomorphicCommitment<Self::P>;
     /// Test whether the given private key and value open the given commitment
     fn open_value(&self, k: &<Self::P as PublicKey>::K, v: u64, commitment: &HomomorphicCommitment<Self::P>) -> bool;
@@ -187,33 +187,33 @@ pub trait HomomorphicCommitmentFactory {
 pub trait ExtendedHomomorphicCommitmentFactory {
     type P: PublicKey;
 
-    /// Create a new commitment with the blinding factor vector k_i and value v provided. The implementing type will
+    /// Create a new commitment with the blinding factor vector **k** and value _v_ provided. The implementing type will
     /// provide the base values
     fn commit(
         &self,
-        k_i: &[<Self::P as PublicKey>::K],
+        k_vec: &[<Self::P as PublicKey>::K],
         v: &<Self::P as PublicKey>::K,
     ) -> Result<HomomorphicCommitment<Self::P>, RangeProofError>;
     /// Return an identity point for addition using the specified base points. This is a commitment to zero with a zero
     /// blinding factor vector on the base points
     fn zero(&self) -> HomomorphicCommitment<Self::P>;
-    /// Test whether the given blinding factor vector k_i and value v open the given commitment
+    /// Test whether the given blinding factor vector **k** and value _v_ open the given commitment
     fn open(
         &self,
-        k_i: &[<Self::P as PublicKey>::K],
+        k_vec: &[<Self::P as PublicKey>::K],
         v: &<Self::P as PublicKey>::K,
         commitment: &HomomorphicCommitment<Self::P>,
     ) -> Result<bool, RangeProofError>;
-    /// Create a commitment from a blinding factor vector k_i and an integer value
+    /// Create a commitment from a blinding factor vector **k** and an integer value
     fn commit_value(
         &self,
-        k_i: &[<Self::P as PublicKey>::K],
+        k_vec: &[<Self::P as PublicKey>::K],
         value: u64,
     ) -> Result<HomomorphicCommitment<Self::P>, RangeProofError>;
     /// Test whether the given private keys and value open the given commitment
     fn open_value(
         &self,
-        k_i: &[<Self::P as PublicKey>::K],
+        k_vec: &[<Self::P as PublicKey>::K],
         v: u64,
         commitment: &HomomorphicCommitment<Self::P>,
     ) -> Result<bool, RangeProofError>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,8 +33,12 @@ pub enum RangeProofError {
     InitializationError(String),
     #[error("Invalid range proof provided: `{0}`")]
     InvalidRangeProof(String),
-    #[error("Inconsistent extension degree: `{0}`")]
-    ExtensionDegree(String),
     #[error("Invalid range proof rewind, the rewind keys provided must be invalid")]
     InvalidRewind,
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Deserialize, Serialize)]
+pub enum CommitmentError {
+    #[error("Inconsistent extension degree: `{0}`")]
+    ExtensionDegree(String),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,14 +25,16 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Error, PartialEq, Deserialize, Serialize)]
 pub enum RangeProofError {
-    #[error("Could not construct range proof")]
-    ProofConstructionError,
+    #[error("Could not construct range proof: `{0}`")]
+    ProofConstructionError(String),
     #[error("The deserialization of the range proof failed")]
     InvalidProof,
-    #[error("Invalid input was provided to the RangeProofService constructor")]
-    InitializationError,
-    #[error("Invalid range proof provided")]
-    InvalidRangeProof,
+    #[error("Invalid input was provided to the RangeProofService constructor: `{0}`")]
+    InitializationError(String),
+    #[error("Invalid range proof provided: `{0}`")]
+    InvalidRangeProof(String),
+    #[error("Inconsistent extension degree: `{0}`")]
+    ExtensionDegree(String),
     #[error("Invalid range proof rewind, the rewind keys provided must be invalid")]
     InvalidRewind,
 }

--- a/src/ffi/keys.rs
+++ b/src/ffi/keys.rs
@@ -30,7 +30,7 @@ use crate::{
     hash::blake2::Blake256,
     keys::{PublicKey, SecretKey},
     ristretto::{
-        pedersen::PedersenCommitmentFactory,
+        pedersen::commitment_factory::PedersenCommitmentFactory,
         RistrettoComSig,
         RistrettoPublicKey,
         RistrettoSchnorr,

--- a/src/rewindable_range_proof.rs
+++ b/src/rewindable_range_proof.rs
@@ -29,7 +29,7 @@ use crate::{
 pub const REWIND_USER_MESSAGE_LENGTH: usize = 21;
 
 pub trait RewindableRangeProofService {
-    type P: Sized;
+    type Proof: Sized;
     type K: SecretKey;
     type PK: PublicKey<K = Self::K>;
 
@@ -43,12 +43,12 @@ pub trait RewindableRangeProofService {
         rewind_key: &Self::K,
         rewind_blinding_key: &Self::K,
         proof_message: &[u8; REWIND_USER_MESSAGE_LENGTH],
-    ) -> Result<Self::P, RangeProofError>;
+    ) -> Result<Self::Proof, RangeProofError>;
 
     /// Rewind a rewindable range proof to reveal the committed value and the 19 byte proof message.
     fn rewind_proof_value_only(
         &self,
-        proof: &Self::P,
+        proof: &Self::Proof,
         commitment: &HomomorphicCommitment<Self::PK>,
         rewind_public_key: &Self::PK,
         rewind_blinding_public_key: &Self::PK,
@@ -58,7 +58,7 @@ pub trait RewindableRangeProofService {
     /// message.
     fn rewind_proof_commitment_data(
         &self,
-        proof: &Self::P,
+        proof: &Self::Proof,
         commitment: &HomomorphicCommitment<Self::PK>,
         rewind_key: &Self::K,
         rewind_blinding_key: &Self::K,

--- a/src/ristretto/constants.rs
+++ b/src/ristretto/constants.rs
@@ -125,11 +125,9 @@ mod test {
             assert_ne!(RISTRETTO_BASEPOINT_POINT, RISTRETTO_NUMS_POINTS[i]);
             assert_ne!(RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_NUMS_POINTS_COMPRESSED[i]);
             // Should all be unique
-            for j in 0..n {
-                if i != j {
-                    assert_ne!(RISTRETTO_NUMS_POINTS[i], RISTRETTO_NUMS_POINTS[j]);
-                    assert_ne!(RISTRETTO_NUMS_POINTS_COMPRESSED[i], RISTRETTO_NUMS_POINTS_COMPRESSED[j]);
-                }
+            for j in i + 1..n {
+                assert_ne!(RISTRETTO_NUMS_POINTS[i], RISTRETTO_NUMS_POINTS[j]);
+                assert_ne!(RISTRETTO_NUMS_POINTS_COMPRESSED[i], RISTRETTO_NUMS_POINTS_COMPRESSED[j]);
             }
         }
     }

--- a/src/ristretto/constants.rs
+++ b/src/ristretto/constants.rs
@@ -22,50 +22,49 @@
 
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 
-/// These points on the Ristretto curve have been created by hashing domain separation labels with SHA512 and converting
-/// the hash output to a Ristretto generator point by using the byte string representation of the hash as input into the
-/// `from_uniform_bytes` constructor in [RistrettoPoint](Struct.RistrettoPoint.html). This process is validated with the
-/// `check_nums_points` test below.
+/// These points on the Ristretto curve have been created by sequentially hashing the Generator point with SHA512 and
+/// using the byte string representation of the hash as input into the `from_uniform_bytes` constructor in
+/// [RistrettoPoint](Struct.RistrettoPoint.html). This process is validated with the `check_nums_points` test below.
 pub const RISTRETTO_NUMS_POINTS_COMPRESSED: [CompressedRistretto; 10] = [
     CompressedRistretto([
-        206, 56, 152, 65, 192, 200, 105, 138, 185, 91, 112, 36, 42, 238, 166, 72, 64, 177, 234, 197, 246, 68, 183, 208,
-        8, 172, 5, 135, 207, 71, 29, 112,
+        144, 202, 17, 205, 108, 98, 39, 203, 10, 188, 57, 226, 113, 12, 68, 74, 230, 97, 126, 168, 24, 152, 231, 22,
+        53, 63, 52, 16, 217, 101, 102, 5,
     ]),
     CompressedRistretto([
-        54, 179, 59, 85, 148, 85, 113, 114, 237, 39, 200, 19, 236, 249, 193, 45, 13, 194, 254, 236, 39, 225, 9, 66,
-        123, 41, 222, 21, 125, 254, 102, 77,
+        158, 163, 67, 196, 112, 228, 87, 33, 101, 243, 64, 56, 81, 223, 107, 32, 221, 251, 206, 241, 171, 132, 207,
+        171, 15, 197, 139, 223, 124, 54, 254, 7,
     ]),
     CompressedRistretto([
-        152, 202, 159, 30, 58, 170, 77, 68, 126, 51, 86, 197, 114, 69, 19, 227, 202, 190, 145, 71, 127, 19, 101, 207,
-        17, 221, 227, 175, 5, 88, 90, 85,
+        48, 188, 62, 20, 154, 63, 125, 42, 172, 191, 231, 48, 225, 158, 154, 7, 119, 59, 83, 83, 219, 98, 32, 99, 185,
+        44, 153, 54, 50, 173, 60, 7,
     ]),
     CompressedRistretto([
-        242, 2, 148, 178, 187, 151, 148, 185, 122, 161, 129, 17, 83, 85, 124, 125, 30, 139, 225, 50, 69, 73, 206, 68,
-        114, 177, 81, 20, 255, 56, 82, 71,
+        142, 16, 136, 206, 212, 150, 29, 136, 213, 177, 113, 189, 154, 52, 40, 68, 84, 120, 154, 69, 95, 70, 236, 55,
+        82, 145, 49, 33, 36, 183, 30, 108,
     ]),
     CompressedRistretto([
-        196, 93, 153, 124, 195, 94, 29, 16, 123, 234, 15, 2, 184, 227, 67, 128, 103, 87, 113, 86, 69, 132, 187, 122,
-        11, 194, 246, 23, 111, 190, 164, 28,
+        112, 19, 255, 145, 136, 246, 135, 216, 133, 201, 90, 218, 110, 88, 11, 35, 141, 231, 33, 12, 85, 193, 246, 36,
+        123, 31, 16, 101, 38, 8, 10, 85,
     ]),
     CompressedRistretto([
-        70, 122, 19, 104, 23, 41, 249, 95, 206, 125, 54, 95, 126, 136, 57, 94, 54, 200, 73, 141, 40, 206, 124, 156,
-        224, 237, 133, 95, 3, 225, 220, 102,
+        122, 234, 197, 53, 77, 120, 8, 171, 35, 80, 105, 62, 45, 2, 30, 42, 99, 188, 47, 231, 194, 119, 210, 5, 107,
+        176, 108, 127, 141, 78, 6, 81,
     ]),
     CompressedRistretto([
-        212, 243, 209, 88, 16, 127, 237, 87, 22, 162, 111, 122, 214, 165, 70, 23, 71, 139, 35, 16, 187, 144, 228, 5,
-        182, 51, 244, 148, 184, 63, 222, 26,
+        228, 224, 63, 227, 33, 214, 87, 20, 172, 223, 193, 247, 88, 37, 111, 121, 204, 69, 49, 213, 30, 143, 121, 244,
+        15, 194, 105, 198, 196, 117, 160, 65,
     ]),
     CompressedRistretto([
-        106, 114, 88, 57, 144, 221, 187, 75, 248, 13, 1, 136, 214, 61, 106, 235, 221, 175, 66, 184, 107, 31, 113, 2,
-        142, 36, 210, 62, 91, 35, 45, 25,
+        136, 214, 134, 144, 253, 111, 238, 89, 110, 128, 92, 250, 34, 30, 126, 40, 119, 21, 166, 201, 46, 148, 100,
+        255, 196, 32, 172, 183, 12, 236, 51, 27,
     ]),
     CompressedRistretto([
-        206, 164, 160, 199, 62, 109, 174, 203, 69, 222, 211, 23, 80, 44, 161, 143, 118, 138, 145, 140, 51, 145, 84,
-        208, 173, 74, 97, 128, 193, 239, 30, 30,
+        204, 102, 24, 189, 15, 12, 192, 35, 132, 29, 173, 74, 19, 204, 46, 55, 166, 35, 14, 36, 48, 80, 214, 220, 196,
+        201, 49, 208, 70, 224, 234, 3,
     ]),
     CompressedRistretto([
-        218, 174, 170, 84, 178, 150, 240, 77, 72, 189, 188, 156, 46, 84, 202, 209, 80, 14, 212, 160, 195, 106, 149, 59,
-        173, 24, 184, 4, 233, 38, 232, 44,
+        96, 230, 255, 101, 87, 7, 198, 66, 73, 210, 250, 146, 78, 49, 146, 182, 149, 220, 88, 44, 180, 246, 214, 140,
+        180, 43, 155, 49, 24, 147, 237, 64,
     ]),
 ];
 
@@ -90,21 +89,21 @@ mod test {
 
     use crate::ristretto::constants::{RISTRETTO_NUMS_POINTS, RISTRETTO_NUMS_POINTS_COMPRESSED};
 
-    /// Generate a set of NUMS points by hashing domain separation labels and converting the hash output to a Ristretto
-    /// generator point. By using `RistrettoPoint::from_uniform_bytes`, the resulting point is a NUMS point if the input
-    /// bytes are from a uniform distribution.
+    /// Generate a set of NUMS points by sequentially hashing the Ristretto255 generator point. By using
+    /// `from_uniform_bytes`, the resulting point is a NUMS point if the input bytes are from a uniform distribution.
     fn nums_ristretto(n: usize) -> (Vec<RistrettoPoint>, Vec<CompressedRistretto>) {
+        let mut val = RISTRETTO_BASEPOINT_POINT.compress().to_bytes();
         let mut points = Vec::with_capacity(n);
         let mut compressed_points = Vec::with_capacity(n);
         let mut a: [u8; 64] = [0; 64];
-        for i in 0..n {
-            let mut data = b"TARI CRYPTO NUMS BASEPOINT LABEL - ".to_vec(); // Domain label
-            data.append(&mut i.to_le_bytes().to_vec()); // Append domain separated label counter
-            let hashed_v = Sha512::digest(&*data);
+        for _ in 0..n {
+            let hashed_v = Sha512::digest(&val[..]);
             a.copy_from_slice(&hashed_v);
             let next_val = RistrettoPoint::from_uniform_bytes(&a);
             points.push(next_val);
-            compressed_points.push(next_val.compress());
+            let next_compressed = next_val.compress();
+            val = next_compressed.to_bytes();
+            compressed_points.push(next_compressed);
         }
         (points, compressed_points)
     }

--- a/src/ristretto/constants.rs
+++ b/src/ristretto/constants.rs
@@ -21,50 +21,49 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
-
-/// These points on the Ristretto curve have been created by sequentially hashing the Generator point with SHA512 and
-/// using the byte string representation of the hash as input into the `from_uniform_bytes` constructor in
-/// [RistrettoPoint](Struct.RistrettoPoint.html). This process is validated with the `check_nums_points` test below.
+/// These points on the Ristretto curve have been created by sequentially hashing a domain separated Generator point
+/// with SHA512 and using the byte string representation of the hash as input into the `from_uniform_bytes` constructor
+/// in [RistrettoPoint](Struct.RistrettoPoint.html). This process is validated with the `check_nums_points` test below.
 pub const RISTRETTO_NUMS_POINTS_COMPRESSED: [CompressedRistretto; 10] = [
     CompressedRistretto([
-        144, 202, 17, 205, 108, 98, 39, 203, 10, 188, 57, 226, 113, 12, 68, 74, 230, 97, 126, 168, 24, 152, 231, 22,
-        53, 63, 52, 16, 217, 101, 102, 5,
+        98, 56, 19, 177, 234, 20, 111, 117, 13, 149, 154, 171, 219, 38, 67, 110, 72, 144, 158, 23, 116, 160, 228, 130,
+        217, 64, 206, 217, 215, 47, 191, 18,
     ]),
     CompressedRistretto([
-        158, 163, 67, 196, 112, 228, 87, 33, 101, 243, 64, 56, 81, 223, 107, 32, 221, 251, 206, 241, 171, 132, 207,
-        171, 15, 197, 139, 223, 124, 54, 254, 7,
+        200, 37, 26, 97, 156, 96, 132, 114, 160, 100, 250, 74, 137, 61, 100, 162, 10, 73, 6, 48, 232, 156, 192, 145,
+        204, 198, 148, 70, 155, 142, 204, 33,
     ]),
     CompressedRistretto([
-        48, 188, 62, 20, 154, 63, 125, 42, 172, 191, 231, 48, 225, 158, 154, 7, 119, 59, 83, 83, 219, 98, 32, 99, 185,
-        44, 153, 54, 50, 173, 60, 7,
+        242, 134, 145, 123, 35, 223, 241, 95, 17, 252, 219, 222, 48, 71, 43, 27, 225, 135, 92, 148, 221, 50, 41, 125,
+        57, 110, 201, 109, 191, 193, 214, 60,
     ]),
     CompressedRistretto([
-        142, 16, 136, 206, 212, 150, 29, 136, 213, 177, 113, 189, 154, 52, 40, 68, 84, 120, 154, 69, 95, 70, 236, 55,
-        82, 145, 49, 33, 36, 183, 30, 108,
+        222, 31, 108, 78, 74, 126, 187, 234, 126, 57, 207, 107, 78, 168, 125, 234, 1, 207, 106, 101, 90, 37, 66, 92,
+        140, 154, 110, 142, 204, 188, 181, 117,
     ]),
     CompressedRistretto([
-        112, 19, 255, 145, 136, 246, 135, 216, 133, 201, 90, 218, 110, 88, 11, 35, 141, 231, 33, 12, 85, 193, 246, 36,
-        123, 31, 16, 101, 38, 8, 10, 85,
+        164, 245, 103, 45, 167, 255, 166, 15, 130, 229, 14, 27, 244, 89, 228, 236, 163, 67, 234, 153, 188, 120, 50,
+        182, 44, 20, 235, 182, 6, 230, 155, 108,
     ]),
     CompressedRistretto([
-        122, 234, 197, 53, 77, 120, 8, 171, 35, 80, 105, 62, 45, 2, 30, 42, 99, 188, 47, 231, 194, 119, 210, 5, 107,
-        176, 108, 127, 141, 78, 6, 81,
+        66, 229, 208, 151, 225, 98, 88, 6, 33, 54, 185, 126, 149, 4, 215, 114, 48, 120, 254, 237, 97, 166, 26, 161, 70,
+        234, 152, 3, 120, 44, 199, 24,
     ]),
     CompressedRistretto([
-        228, 224, 63, 227, 33, 214, 87, 20, 172, 223, 193, 247, 88, 37, 111, 121, 204, 69, 49, 213, 30, 143, 121, 244,
-        15, 194, 105, 198, 196, 117, 160, 65,
+        234, 153, 246, 145, 163, 1, 37, 83, 29, 141, 204, 207, 14, 7, 148, 2, 132, 77, 48, 146, 87, 244, 29, 92, 0, 23,
+        135, 180, 38, 252, 113, 119,
     ]),
     CompressedRistretto([
-        136, 214, 134, 144, 253, 111, 238, 89, 110, 128, 92, 250, 34, 30, 126, 40, 119, 21, 166, 201, 46, 148, 100,
-        255, 196, 32, 172, 183, 12, 236, 51, 27,
+        136, 16, 34, 235, 193, 68, 129, 24, 197, 150, 189, 17, 69, 8, 239, 220, 52, 98, 249, 229, 213, 216, 219, 138,
+        154, 94, 182, 224, 134, 1, 2, 76,
     ]),
     CompressedRistretto([
-        204, 102, 24, 189, 15, 12, 192, 35, 132, 29, 173, 74, 19, 204, 46, 55, 166, 35, 14, 36, 48, 80, 214, 220, 196,
-        201, 49, 208, 70, 224, 234, 3,
+        208, 187, 119, 38, 163, 204, 121, 219, 111, 215, 141, 8, 134, 238, 82, 60, 245, 224, 139, 255, 111, 252, 4, 81,
+        179, 238, 176, 77, 88, 210, 144, 123,
     ]),
     CompressedRistretto([
-        96, 230, 255, 101, 87, 7, 198, 66, 73, 210, 250, 146, 78, 49, 146, 182, 149, 220, 88, 44, 180, 246, 214, 140,
-        180, 43, 155, 49, 24, 147, 237, 64,
+        110, 128, 149, 108, 46, 193, 113, 71, 214, 210, 246, 51, 128, 210, 102, 205, 47, 27, 179, 247, 191, 20, 106,
+        199, 84, 218, 136, 137, 120, 9, 133, 93,
     ]),
 ];
 
@@ -79,9 +78,6 @@ lazy_static! {
     };
 }
 
-/// The NUMS Ristretto point `H`
-pub const RISTRETTO_PEDERSEN_H: CompressedRistretto = RISTRETTO_NUMS_POINTS_COMPRESSED[0];
-
 #[cfg(test)]
 mod test {
     use curve25519_dalek::{
@@ -92,15 +88,18 @@ mod test {
 
     use crate::ristretto::constants::{RISTRETTO_NUMS_POINTS, RISTRETTO_NUMS_POINTS_COMPRESSED};
 
-    /// Generate a set of NUMS points by sequentially hashing the Ristretto255 generator point. By using
+    /// Generate a set of NUMS points by sequentially hashing domain separated Ristretto255 generator point. By using
     /// `from_uniform_bytes`, the resulting point is a NUMS point if the input bytes are from a uniform distribution.
     fn nums_ristretto(n: usize) -> (Vec<RistrettoPoint>, Vec<CompressedRistretto>) {
         let mut val = RISTRETTO_BASEPOINT_POINT.compress().to_bytes();
         let mut points = Vec::with_capacity(n);
         let mut compressed_points = Vec::with_capacity(n);
         let mut a: [u8; 64] = [0; 64];
-        for _ in 0..n {
-            let hashed_v = Sha512::digest(&val[..]);
+        for i in 0..n {
+            let mut data = b"TARI CRYPTO - ".to_vec();
+            data.append(&mut i.to_le_bytes().to_vec());
+            data.append(&mut val.to_vec());
+            let hashed_v = Sha512::digest(&*data);
             a.copy_from_slice(&hashed_v);
             let next_val = RistrettoPoint::from_uniform_bytes(&a);
             points.push(next_val);

--- a/src/ristretto/constants.rs
+++ b/src/ristretto/constants.rs
@@ -26,44 +26,44 @@ use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 /// in [RistrettoPoint](Struct.RistrettoPoint.html). This process is validated with the `check_nums_points` test below.
 pub const RISTRETTO_NUMS_POINTS_COMPRESSED: [CompressedRistretto; 10] = [
     CompressedRistretto([
-        98, 56, 19, 177, 234, 20, 111, 117, 13, 149, 154, 171, 219, 38, 67, 110, 72, 144, 158, 23, 116, 160, 228, 130,
-        217, 64, 206, 217, 215, 47, 191, 18,
+        206, 56, 152, 65, 192, 200, 105, 138, 185, 91, 112, 36, 42, 238, 166, 72, 64, 177, 234, 197, 246, 68, 183, 208,
+        8, 172, 5, 135, 207, 71, 29, 112,
     ]),
     CompressedRistretto([
-        200, 37, 26, 97, 156, 96, 132, 114, 160, 100, 250, 74, 137, 61, 100, 162, 10, 73, 6, 48, 232, 156, 192, 145,
-        204, 198, 148, 70, 155, 142, 204, 33,
+        54, 179, 59, 85, 148, 85, 113, 114, 237, 39, 200, 19, 236, 249, 193, 45, 13, 194, 254, 236, 39, 225, 9, 66,
+        123, 41, 222, 21, 125, 254, 102, 77,
     ]),
     CompressedRistretto([
-        242, 134, 145, 123, 35, 223, 241, 95, 17, 252, 219, 222, 48, 71, 43, 27, 225, 135, 92, 148, 221, 50, 41, 125,
-        57, 110, 201, 109, 191, 193, 214, 60,
+        152, 202, 159, 30, 58, 170, 77, 68, 126, 51, 86, 197, 114, 69, 19, 227, 202, 190, 145, 71, 127, 19, 101, 207,
+        17, 221, 227, 175, 5, 88, 90, 85,
     ]),
     CompressedRistretto([
-        222, 31, 108, 78, 74, 126, 187, 234, 126, 57, 207, 107, 78, 168, 125, 234, 1, 207, 106, 101, 90, 37, 66, 92,
-        140, 154, 110, 142, 204, 188, 181, 117,
+        242, 2, 148, 178, 187, 151, 148, 185, 122, 161, 129, 17, 83, 85, 124, 125, 30, 139, 225, 50, 69, 73, 206, 68,
+        114, 177, 81, 20, 255, 56, 82, 71,
     ]),
     CompressedRistretto([
-        164, 245, 103, 45, 167, 255, 166, 15, 130, 229, 14, 27, 244, 89, 228, 236, 163, 67, 234, 153, 188, 120, 50,
-        182, 44, 20, 235, 182, 6, 230, 155, 108,
+        196, 93, 153, 124, 195, 94, 29, 16, 123, 234, 15, 2, 184, 227, 67, 128, 103, 87, 113, 86, 69, 132, 187, 122,
+        11, 194, 246, 23, 111, 190, 164, 28,
     ]),
     CompressedRistretto([
-        66, 229, 208, 151, 225, 98, 88, 6, 33, 54, 185, 126, 149, 4, 215, 114, 48, 120, 254, 237, 97, 166, 26, 161, 70,
-        234, 152, 3, 120, 44, 199, 24,
+        70, 122, 19, 104, 23, 41, 249, 95, 206, 125, 54, 95, 126, 136, 57, 94, 54, 200, 73, 141, 40, 206, 124, 156,
+        224, 237, 133, 95, 3, 225, 220, 102,
     ]),
     CompressedRistretto([
-        234, 153, 246, 145, 163, 1, 37, 83, 29, 141, 204, 207, 14, 7, 148, 2, 132, 77, 48, 146, 87, 244, 29, 92, 0, 23,
-        135, 180, 38, 252, 113, 119,
+        212, 243, 209, 88, 16, 127, 237, 87, 22, 162, 111, 122, 214, 165, 70, 23, 71, 139, 35, 16, 187, 144, 228, 5,
+        182, 51, 244, 148, 184, 63, 222, 26,
     ]),
     CompressedRistretto([
-        136, 16, 34, 235, 193, 68, 129, 24, 197, 150, 189, 17, 69, 8, 239, 220, 52, 98, 249, 229, 213, 216, 219, 138,
-        154, 94, 182, 224, 134, 1, 2, 76,
+        106, 114, 88, 57, 144, 221, 187, 75, 248, 13, 1, 136, 214, 61, 106, 235, 221, 175, 66, 184, 107, 31, 113, 2,
+        142, 36, 210, 62, 91, 35, 45, 25,
     ]),
     CompressedRistretto([
-        208, 187, 119, 38, 163, 204, 121, 219, 111, 215, 141, 8, 134, 238, 82, 60, 245, 224, 139, 255, 111, 252, 4, 81,
-        179, 238, 176, 77, 88, 210, 144, 123,
+        206, 164, 160, 199, 62, 109, 174, 203, 69, 222, 211, 23, 80, 44, 161, 143, 118, 138, 145, 140, 51, 145, 84,
+        208, 173, 74, 97, 128, 193, 239, 30, 30,
     ]),
     CompressedRistretto([
-        110, 128, 149, 108, 46, 193, 113, 71, 214, 210, 246, 51, 128, 210, 102, 205, 47, 27, 179, 247, 191, 20, 106,
-        199, 84, 218, 136, 137, 120, 9, 133, 93,
+        218, 174, 170, 84, 178, 150, 240, 77, 72, 189, 188, 156, 46, 84, 202, 209, 80, 14, 212, 160, 195, 106, 149, 59,
+        173, 24, 184, 4, 233, 38, 232, 44,
     ]),
 ];
 
@@ -80,32 +80,26 @@ lazy_static! {
 
 #[cfg(test)]
 mod test {
-    use curve25519_dalek::{
-        constants::RISTRETTO_BASEPOINT_POINT,
-        ristretto::{CompressedRistretto, RistrettoPoint},
-    };
+    use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
     use sha2::{Digest, Sha512};
 
     use crate::ristretto::constants::{RISTRETTO_NUMS_POINTS, RISTRETTO_NUMS_POINTS_COMPRESSED};
 
-    /// Generate a set of NUMS points by sequentially hashing domain separated Ristretto255 generator point. By using
-    /// `from_uniform_bytes`, the resulting point is a NUMS point if the input bytes are from a uniform distribution.
+    /// Generate a set of NUMS points by hashing domain separation labels and converting the hash output to a Ristretto
+    /// generator point. By using `RistrettoPoint::from_uniform_bytes`, the resulting point is a NUMS point if the input
+    /// bytes are from a uniform distribution.
     fn nums_ristretto(n: usize) -> (Vec<RistrettoPoint>, Vec<CompressedRistretto>) {
-        let mut val = RISTRETTO_BASEPOINT_POINT.compress().to_bytes();
         let mut points = Vec::with_capacity(n);
         let mut compressed_points = Vec::with_capacity(n);
         let mut a: [u8; 64] = [0; 64];
         for i in 0..n {
-            let mut data = b"TARI CRYPTO - ".to_vec();
+            let mut data = b"TARI CRYPTO NUMS BASEPOINT LABEL - ".to_vec();
             data.append(&mut i.to_le_bytes().to_vec());
-            data.append(&mut val.to_vec());
             let hashed_v = Sha512::digest(&*data);
             a.copy_from_slice(&hashed_v);
             let next_val = RistrettoPoint::from_uniform_bytes(&a);
             points.push(next_val);
-            let next_compressed = next_val.compress();
-            val = next_compressed.to_bytes();
-            compressed_points.push(next_compressed);
+            compressed_points.push(next_val.compress());
         }
         (points, compressed_points)
     }

--- a/src/ristretto/dalek_range_proof.rs
+++ b/src/ristretto/dalek_range_proof.rs
@@ -103,8 +103,8 @@ impl RangeProofService for DalekRangeProofService {
 
 impl RewindableRangeProofService for DalekRangeProofService {
     type K = RistrettoSecretKey;
-    type P = Vec<u8>;
     type PK = RistrettoPublicKey;
+    type Proof = Vec<u8>;
 
     fn construct_proof_with_rewind_key(
         &self,
@@ -139,7 +139,7 @@ impl RewindableRangeProofService for DalekRangeProofService {
 
     fn rewind_proof_value_only(
         &self,
-        proof: &Self::P,
+        proof: &Self::Proof,
         commitment: &PedersenCommitment,
         rewind_public_key: &RistrettoPublicKey,
         rewind_blinding_public_key: &RistrettoPublicKey,
@@ -173,7 +173,7 @@ impl RewindableRangeProofService for DalekRangeProofService {
 
     fn rewind_proof_commitment_data(
         &self,
-        proof: &Self::P,
+        proof: &Self::Proof,
         commitment: &PedersenCommitment,
         rewind_key: &RistrettoSecretKey,
         rewind_blinding_key: &RistrettoSecretKey,

--- a/src/ristretto/dalek_range_proof.rs
+++ b/src/ristretto/dalek_range_proof.rs
@@ -34,7 +34,7 @@ use crate::{
     range_proof::RangeProofService,
     rewindable_range_proof::{FullRewindResult, RewindResult, RewindableRangeProofService, REWIND_USER_MESSAGE_LENGTH},
     ristretto::{
-        pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
         RistrettoPublicKey,
         RistrettoSecretKey,
     },
@@ -56,7 +56,7 @@ impl DalekRangeProofService {
     /// where valid range values are 8, 16, 32 and 64.
     pub fn new(range: usize, base: &PedersenCommitmentFactory) -> Result<DalekRangeProofService, RangeProofError> {
         if range == 0 || (range | MASK != MASK) {
-            return Err(RangeProofError::InitializationError);
+            return Err(RangeProofError::InitializationError("Range not valid".to_string()));
         }
         let pc_gens = PedersenGens {
             B_blinding: base.G,
@@ -80,7 +80,7 @@ impl RangeProofService for DalekRangeProofService {
         let mut pt = Transcript::new(b"tari");
         let k = key.0;
         let (proof, _) = DalekProof::prove_single(&self.bp_gens, &self.pc_gens, &mut pt, value, &k, self.range)
-            .map_err(|_| RangeProofError::ProofConstructionError)?;
+            .map_err(|e| RangeProofError::ProofConstructionError(e.to_string()))?;
         Ok(proof.to_bytes())
     }
 
@@ -133,7 +133,7 @@ impl RewindableRangeProofService for DalekRangeProofService {
             &rbk,
             &full_proof_message,
         )
-        .map_err(|_| RangeProofError::ProofConstructionError)?;
+        .map_err(|e| RangeProofError::ProofConstructionError(e.to_string()))?;
         Ok(proof.to_bytes())
     }
 
@@ -162,7 +162,7 @@ impl RewindableRangeProofService for DalekRangeProofService {
                 &rewind_nonce_1,
                 &rewind_nonce_2,
             )
-            .map_err(|_| RangeProofError::ProofConstructionError)?;
+            .map_err(|e| RangeProofError::ProofConstructionError(e.to_string()))?;
         if &proof_message[..REWIND_CHECK_MESSAGE.len()] != REWIND_CHECK_MESSAGE {
             return Err(RangeProofError::InvalidRewind);
         }
@@ -228,7 +228,7 @@ mod test {
         rewindable_range_proof::RewindableRangeProofService,
         ristretto::{
             dalek_range_proof::DalekRangeProofService,
-            pedersen::PedersenCommitmentFactory,
+            pedersen::commitment_factory::PedersenCommitmentFactory,
             RistrettoPublicKey,
             RistrettoSecretKey,
         },
@@ -325,10 +325,8 @@ mod test {
     #[test]
     fn non_power_of_two_range() {
         let base = PedersenCommitmentFactory::default();
-        assert!(matches!(
-            DalekRangeProofService::new(10, &base),
-            Err(RangeProofError::InitializationError)
-        ));
+        let _error = RangeProofError::InitializationError("Range not valid".to_string());
+        assert!(matches!(DalekRangeProofService::new(10, &base), Err(_error)));
     }
 
     #[test]

--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -268,24 +268,32 @@ mod test {
         assert_eq!(&result, "b1b43e91f6d6109f");
 
         // Test 'Ord' and 'PartialOrd' implementations
-        let mut values = (value - 100..value - 1).collect::<Vec<_>>();
-        values.extend((value + 1..value + 100).collect::<Vec<_>>());
+        let mut values = (value - 10..value).collect::<Vec<_>>();
+        values.extend((value + 1..value + 11).collect::<Vec<_>>());
+        let (mut tested_less_than, mut tested_greater_than) = (false, false);
         for val in values {
             let c3 = factory.commit_value(&k, val);
             assert_ne!(c2, c3);
+            assert_ne!(c2.cmp(&c3), c3.cmp(&c2));
             if c2 > c3 {
                 assert!(c3 < c2);
+                assert!(matches!(c2.cmp(&c3), std::cmp::Ordering::Greater));
+                assert!(matches!(c3.cmp(&c2), std::cmp::Ordering::Less));
+                tested_less_than = true;
             }
             if c2 < c3 {
                 assert!(c3 > c2);
-            }
-            assert_ne!(c2.cmp(&c3), c3.cmp(&c2));
-            if c2.cmp(&c3) == std::cmp::Ordering::Less {
+                assert!(matches!(c2.cmp(&c3), std::cmp::Ordering::Less));
                 assert!(matches!(c3.cmp(&c2), std::cmp::Ordering::Greater));
+                tested_greater_than = true;
             }
-            if c2.cmp(&c3) == std::cmp::Ordering::Greater {
-                assert!(matches!(c3.cmp(&c2), std::cmp::Ordering::Less));
+            if tested_less_than && tested_greater_than {
+                break;
             }
         }
+        assert!(
+            tested_less_than && tested_greater_than,
+            "Try extending the range of values to compare"
+        );
     }
 }

--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -255,7 +255,7 @@ mod test {
         // Test 'Debug' implementation
         assert_eq!(
             format!("{:?}", c1),
-            "HomomorphicCommitment(601cdc5c97e94bb16ae56f75430f8ab3ef4703c7d89ca9592e8acadc81629f0e)"
+            "HomomorphicCommitment(f09a7f46c5e3cbadc4c1e84c10278cffab2cb902f7b6f37223c88dd548877a6a)"
         );
         // Test 'Clone' implementation
         let c2 = c1.clone();
@@ -265,7 +265,7 @@ mod test {
         let mut hasher = DefaultHasher::new();
         c1.hash(&mut hasher);
         let result = format!("{:x}", hasher.finish());
-        assert_eq!(&result, "699d38210741194e");
+        assert_eq!(&result, "b1b43e91f6d6109f");
 
         // Test 'Ord' and 'PartialOrd' implementations
         let mut values = (value - 100..value - 1).collect::<Vec<_>>();

--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -1,45 +1,13 @@
-// Copyright 2019 The Tari Project
-//
-// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-// following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-// disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-// following disclaimer in the documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
-// products derived from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-use std::{borrow::Borrow, iter::Sum};
-
-use curve25519_dalek::{
-    constants::RISTRETTO_BASEPOINT_POINT,
-    ristretto::RistrettoPoint,
-    scalar::Scalar,
-    traits::MultiscalarMul,
-};
+use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar, traits::MultiscalarMul};
 
 use crate::{
     commitment::{HomomorphicCommitment, HomomorphicCommitmentFactory},
-    ristretto::{constants::RISTRETTO_NUMS_POINTS, RistrettoPublicKey, RistrettoSecretKey},
+    ristretto::{
+        pedersen::{PedersenCommitment, RISTRETTO_PEDERSEN_G, RISTRETTO_PEDERSEN_H},
+        RistrettoPublicKey,
+        RistrettoSecretKey,
+    },
 };
-
-pub const RISTRETTO_PEDERSEN_G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
-lazy_static! {
-    pub static ref RISTRETTO_PEDERSEN_H: RistrettoPoint = RISTRETTO_NUMS_POINTS[0];
-}
-
-pub type PedersenCommitment = HomomorphicCommitment<RistrettoPublicKey>;
 
 /// Generates Pederson commitments `k.G + v.H` using the provided base
 /// [RistrettoPoints](curve25519_dalek::ristretto::RistrettoPoints).
@@ -90,24 +58,9 @@ impl HomomorphicCommitmentFactory for PedersenCommitmentFactory {
         self.commit(k, &v)
     }
 
-    fn open_value(&self, k: &RistrettoSecretKey, v: u64, commitment: &HomomorphicCommitment<Self::P>) -> bool {
+    fn open_value(&self, k: &RistrettoSecretKey, v: u64, commitment: &PedersenCommitment) -> bool {
         let kv = RistrettoSecretKey::from(v);
         self.open(k, &kv, commitment)
-    }
-}
-
-impl<T> Sum<T> for PedersenCommitment
-where T: Borrow<PedersenCommitment>
-{
-    fn sum<I>(iter: I) -> Self
-    where I: Iterator<Item = T> {
-        let mut total = RistrettoPoint::default();
-        for c in iter {
-            let commitment = c.borrow();
-            total += RistrettoPoint::from(&commitment.0);
-        }
-        let sum = RistrettoPublicKey::new_from_pk(total);
-        HomomorphicCommitment(sum)
     }
 }
 
@@ -119,43 +72,20 @@ mod test {
         hash::{Hash, Hasher},
     };
 
-    use tari_utilities::{message_format::MessageFormat, ByteArray};
+    use tari_utilities::message_format::MessageFormat;
 
     use super::*;
-    use crate::keys::{PublicKey, SecretKey};
+    use crate::{
+        commitment::HomomorphicCommitmentFactory,
+        keys::{PublicKey, SecretKey},
+        ristretto::{pedersen::commitment_factory::PedersenCommitmentFactory, RistrettoSecretKey},
+    };
 
     #[test]
     fn check_default_base() {
         let base = PedersenCommitmentFactory::default();
         assert_eq!(base.G, RISTRETTO_PEDERSEN_G);
         assert_eq!(base.H, *RISTRETTO_PEDERSEN_H)
-    }
-
-    #[test]
-    fn pubkey_roundtrip() {
-        let mut rng = rand::thread_rng();
-        let (_, p) = RistrettoPublicKey::random_keypair(&mut rng);
-        let c = PedersenCommitment::from_public_key(&p);
-        assert_eq!(c.as_public_key(), &p);
-        let c2 = PedersenCommitment::from_bytes(c.as_bytes()).unwrap();
-        assert_eq!(c, c2);
-    }
-
-    #[test]
-    fn commitment_sub() {
-        let mut rng = rand::thread_rng();
-        let (_, a) = RistrettoPublicKey::random_keypair(&mut rng);
-        let (_, b) = RistrettoPublicKey::random_keypair(&mut rng);
-        let c = &a + &b;
-        let a = PedersenCommitment::from_public_key(&a);
-        let b = PedersenCommitment::from_public_key(&b);
-        let c = PedersenCommitment::from_public_key(&c);
-        assert_eq!(b, &c - &a);
-    }
-
-    #[test]
-    fn check_g_ne_h() {
-        assert_ne!(RISTRETTO_PEDERSEN_G, *RISTRETTO_PEDERSEN_H);
     }
 
     /// Simple test for open: Generate 100 random sets of scalars and calculate the Pedersen commitment for them.
@@ -231,6 +161,12 @@ mod test {
         assert!(factory.open(&(&k1 + &k2), &v1, &c2));
     }
 
+    /// Test addition of individual homomorphic commitments to be equal to a single vector homomorphic commitment.
+    /// $$
+    ///   sum(C_j) = sum((v.H + k.G)_j) = sum(v_j).H + sum(k_j).G
+    /// $$
+    /// and
+    /// `open(sum(k_j), sum(v_j))` is true for `sum(C_j)`
     #[test]
     fn sum_commitment_vector() {
         let mut rng = rand::thread_rng();
@@ -279,7 +215,7 @@ mod test {
         // Test Debug impl
         assert_eq!(
             format!("{:?}", c1),
-            "HomomorphicCommitment(f09a7f46c5e3cbadc4c1e84c10278cffab2cb902f7b6f37223c88dd548877a6a)"
+            "HomomorphicCommitment(9801c7785217e0c973e9b85508c6eebcb74b257a6f825630e17282b81b7fcd78)"
         );
         // test Clone impl
         let c2 = c1.clone();
@@ -288,18 +224,12 @@ mod test {
         let mut hasher = DefaultHasher::new();
         c1.hash(&mut hasher);
         let result = format!("{:x}", hasher.finish());
-        assert_eq!(&result, "b1b43e91f6d6109f");
+        assert_eq!(&result, "1ef11e8d243c886e");
         // test Ord and PartialOrd impl
         let c3 = factory.commit_value(&k, 2049);
         assert!(c2 > c3);
         assert!(c2 != c3);
         assert!(c3 < c2);
         assert!(matches!(c2.cmp(&c3), std::cmp::Ordering::Greater));
-    }
-
-    #[test]
-    fn default_value() {
-        let c = PedersenCommitment::default();
-        assert_eq!(c, PedersenCommitment::from_public_key(&RistrettoPublicKey::default()));
     }
 }

--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -211,25 +211,43 @@ mod test {
     fn derived_methods() {
         let factory = PedersenCommitmentFactory::default();
         let k = RistrettoSecretKey::from(1024);
-        let c1 = factory.commit_value(&k, 2048);
-        // Test Debug impl
+        let value = 2048;
+        let c1 = factory.commit_value(&k, value);
+
+        // Test 'Debug' implementation
         assert_eq!(
             format!("{:?}", c1),
-            "HomomorphicCommitment(9801c7785217e0c973e9b85508c6eebcb74b257a6f825630e17282b81b7fcd78)"
+            "HomomorphicCommitment(601cdc5c97e94bb16ae56f75430f8ab3ef4703c7d89ca9592e8acadc81629f0e)"
         );
-        // test Clone impl
+        // Test 'Clone' implementation
         let c2 = c1.clone();
         assert_eq!(c1, c2);
-        // test hash impl
+
+        // Test hash implementation
         let mut hasher = DefaultHasher::new();
         c1.hash(&mut hasher);
         let result = format!("{:x}", hasher.finish());
-        assert_eq!(&result, "1ef11e8d243c886e");
-        // test Ord and PartialOrd impl
-        let c3 = factory.commit_value(&k, 2049);
-        assert!(c2 > c3);
-        assert!(c2 != c3);
-        assert!(c3 < c2);
-        assert!(matches!(c2.cmp(&c3), std::cmp::Ordering::Greater));
+        assert_eq!(&result, "699d38210741194e");
+
+        // Test 'Ord' and 'PartialOrd' implementations
+        let mut values = (value - 100..value - 1).collect::<Vec<_>>();
+        values.extend((value + 1..value + 100).collect::<Vec<_>>());
+        for val in values {
+            let c3 = factory.commit_value(&k, val);
+            assert_ne!(c2, c3);
+            if c2 > c3 {
+                assert!(c3 < c2);
+            }
+            if c2 < c3 {
+                assert!(c3 > c2);
+            }
+            assert_ne!(c2.cmp(&c3), c3.cmp(&c2));
+            if c2.cmp(&c3) == std::cmp::Ordering::Less {
+                assert!(matches!(c3.cmp(&c2), std::cmp::Ordering::Greater));
+            }
+            if c2.cmp(&c3) == std::cmp::Ordering::Greater {
+                assert!(matches!(c3.cmp(&c2), std::cmp::Ordering::Less));
+            }
+        }
     }
 }

--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -1,4 +1,29 @@
-use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar, traits::MultiscalarMul};
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use curve25519_dalek::{
+    ristretto::RistrettoPoint,
+    traits::{Identity, MultiscalarMul},
+};
 
 use crate::{
     commitment::{HomomorphicCommitment, HomomorphicCommitmentFactory},
@@ -43,9 +68,7 @@ impl HomomorphicCommitmentFactory for PedersenCommitmentFactory {
     }
 
     fn zero(&self) -> PedersenCommitment {
-        let zero = Scalar::zero();
-        let c = RistrettoPoint::multiscalar_mul(&[zero, zero], &[self.H, self.G]);
-        HomomorphicCommitment(RistrettoPublicKey::new_from_pk(c))
+        HomomorphicCommitment(RistrettoPublicKey::new_from_pk(RistrettoPoint::identity()))
     }
 
     fn open(&self, k: &RistrettoSecretKey, v: &RistrettoSecretKey, commitment: &PedersenCommitment) -> bool {
@@ -72,6 +95,7 @@ mod test {
         hash::{Hash, Hasher},
     };
 
+    use curve25519_dalek::scalar::Scalar;
     use tari_utilities::message_format::MessageFormat;
 
     use super::*;
@@ -86,6 +110,20 @@ mod test {
         let base = PedersenCommitmentFactory::default();
         assert_eq!(base.G, RISTRETTO_PEDERSEN_G);
         assert_eq!(base.H, *RISTRETTO_PEDERSEN_H)
+    }
+
+    #[test]
+    /// Verify that the identity point is equal to a commitment to zero with a zero blinding factor on the base point
+    fn check_zero() {
+        let c = RistrettoPoint::multiscalar_mul(&[Scalar::zero(), Scalar::zero()], &[
+            RISTRETTO_PEDERSEN_G,
+            *RISTRETTO_PEDERSEN_H,
+        ]);
+        let factory = PedersenCommitmentFactory::default();
+        assert_eq!(
+            HomomorphicCommitment(RistrettoPublicKey::new_from_pk(c)),
+            PedersenCommitmentFactory::zero(&factory)
+        );
     }
 
     /// Simple test for open: Generate 100 random sets of scalars and calculate the Pedersen commitment for them.

--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -268,8 +268,8 @@ mod test {
         assert_eq!(&result, "b1b43e91f6d6109f");
 
         // Test 'Ord' and 'PartialOrd' implementations
-        let mut values = (value - 10..value).collect::<Vec<_>>();
-        values.extend((value + 1..value + 11).collect::<Vec<_>>());
+        let mut values = (value - 100..value).collect::<Vec<_>>();
+        values.extend((value + 1..value + 101).collect::<Vec<_>>());
         let (mut tested_less_than, mut tested_greater_than) = (false, false);
         for val in values {
             let c3 = factory.commit_value(&k, val);

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -60,11 +60,11 @@ impl ExtendedPedersenCommitmentFactory {
         }
         let g_base_vec = std::iter::once(&RISTRETTO_PEDERSEN_G)
             .chain(RISTRETTO_NUMS_POINTS[1..extension_degree as usize].iter())
-            .cloned()
+            .copied()
             .collect();
         let g_base_compressed_vec = std::iter::once(&RISTRETTO_PEDERSEN_G_COMPRESSED)
             .chain(RISTRETTO_NUMS_POINTS_COMPRESSED[1..extension_degree as usize].iter())
-            .cloned()
+            .copied()
             .collect();
         Ok(Self(PedersenGens {
             h_base: *RISTRETTO_PEDERSEN_H,
@@ -442,8 +442,8 @@ mod test {
             }
 
             // Test 'Ord' and 'PartialOrd' implementations
-            let mut values = (value - 10..value).collect::<Vec<_>>();
-            values.extend((value + 1..value + 11).collect::<Vec<_>>());
+            let mut values = (value - 100..value).collect::<Vec<_>>();
+            values.extend((value + 1..value + 101).collect::<Vec<_>>());
             let (mut tested_less_than, mut tested_greater_than) = (false, false);
             for val in values {
                 let c3 = factory.commit_value(&k_vec, val).unwrap();

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -1,0 +1,415 @@
+use bulletproofs_plus::{generators::pedersen_gens::ExtensionDegree, PedersenGens};
+use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar, traits::MultiscalarMul};
+
+use crate::{
+    commitment::{ExtendedHomomorphicCommitmentFactory, HomomorphicCommitment},
+    errors::RangeProofError,
+    ristretto::{
+        constants::{RISTRETTO_NUMS_POINTS, RISTRETTO_NUMS_POINTS_COMPRESSED},
+        pedersen::{
+            PedersenCommitment,
+            RISTRETTO_PEDERSEN_G,
+            RISTRETTO_PEDERSEN_G_COMPRESSED,
+            RISTRETTO_PEDERSEN_H,
+            RISTRETTO_PEDERSEN_H_COMPRESSED,
+        },
+        RistrettoPublicKey,
+        RistrettoSecretKey,
+    },
+};
+
+/// Generates extended Pederson commitments `sum(k_i.G_i) + v.H` using the provided base
+/// [RistrettoPoints](curve25519_dalek::ristretto::RistrettoPoints).
+/// Notes:
+///  - Homomorphism with public key only holds for extended commitments with `ExtensionDegree::Zero`
+///  - 'Ord' and 'PartialOrd' are undefined for extended commitments other than `ExtensionDegree::Zero`
+#[derive(Debug, PartialEq, Clone)]
+pub struct ExtendedPedersenCommitmentFactory(pub(crate) PedersenGens<RistrettoPoint>);
+
+impl ExtendedPedersenCommitmentFactory {
+    /// Create a new Extended Pedersen Ristretto Commitment factory for the required extension degree using
+    /// pre-calculated compressed constants - we only hold references to the static generator points.
+    pub fn new_with_extension_degree(extension_degree: ExtensionDegree) -> Result<Self, RangeProofError> {
+        if extension_degree as usize > RISTRETTO_NUMS_POINTS.len() ||
+            extension_degree as usize > RISTRETTO_NUMS_POINTS_COMPRESSED.len()
+        {
+            return Err(RangeProofError::ExtensionDegree(
+                "Not enough Ristretto NUMS points to construct the extended commitment factory".to_string(),
+            ));
+        }
+        let mut g_base_vec = Vec::with_capacity(extension_degree as usize);
+        g_base_vec.push(RISTRETTO_PEDERSEN_G);
+        let mut g_base_compressed_vec = Vec::with_capacity(extension_degree as usize);
+        g_base_compressed_vec.push(RISTRETTO_PEDERSEN_G_COMPRESSED);
+        for i in 1..extension_degree as usize {
+            g_base_vec.push(RISTRETTO_NUMS_POINTS[i]);
+            g_base_compressed_vec.push(RISTRETTO_NUMS_POINTS_COMPRESSED[i]);
+        }
+        Ok(Self(PedersenGens {
+            h_base: *RISTRETTO_PEDERSEN_H,
+            h_base_compressed: *RISTRETTO_PEDERSEN_H_COMPRESSED,
+            g_base_vec,
+            g_base_compressed_vec,
+            extension_degree,
+        }))
+    }
+}
+
+impl Default for ExtendedPedersenCommitmentFactory {
+    /// The default Extended Pedersen Ristretto Commitment factory is of extension degree Zero; this corresponds to
+    /// the default non extended Pedersen Ristretto Commitment factory.
+    fn default() -> Self {
+        Self::new_with_extension_degree(ExtensionDegree::Zero).expect("Ristretto default base points not defined!")
+    }
+}
+
+impl ExtendedHomomorphicCommitmentFactory for ExtendedPedersenCommitmentFactory {
+    type P = RistrettoPublicKey;
+
+    fn commit(
+        &self,
+        k_i: &[RistrettoSecretKey],
+        v: &RistrettoSecretKey,
+    ) -> Result<PedersenCommitment, RangeProofError> {
+        let k_i: Vec<Scalar> = k_i.to_vec().iter().map(|k| k.0).collect();
+        let c = self
+            .0
+            .commit(v.0, &k_i)
+            .map_err(|e| RangeProofError::ExtensionDegree(e.to_string()))?;
+        Ok(HomomorphicCommitment(RistrettoPublicKey::new_from_pk(c)))
+    }
+
+    fn zero(&self) -> PedersenCommitment {
+        let extension_degree = self.0.extension_degree as usize;
+        let zero = vec![Scalar::zero(); extension_degree + 1];
+        let mut points = Vec::with_capacity(extension_degree + 1);
+        points.push(self.0.h_base);
+        points.append(&mut self.0.g_base_vec.clone());
+        let c = RistrettoPoint::multiscalar_mul(&zero, &self.0.g_base_vec);
+        HomomorphicCommitment(RistrettoPublicKey::new_from_pk(c))
+    }
+
+    fn open(
+        &self,
+        k_i: &[RistrettoSecretKey],
+        v: &RistrettoSecretKey,
+        commitment: &PedersenCommitment,
+    ) -> Result<bool, RangeProofError> {
+        let c_test = self
+            .commit(k_i, v)
+            .map_err(|e| RangeProofError::ExtensionDegree(e.to_string()))?;
+        Ok(commitment == &c_test)
+    }
+
+    fn commit_value(&self, k_i: &[RistrettoSecretKey], value: u64) -> Result<PedersenCommitment, RangeProofError> {
+        let v = RistrettoSecretKey::from(value);
+        self.commit(k_i, &v)
+    }
+
+    fn open_value(
+        &self,
+        k_i: &[RistrettoSecretKey],
+        v: u64,
+        commitment: &PedersenCommitment,
+    ) -> Result<bool, RangeProofError> {
+        let kv = RistrettoSecretKey::from(v);
+        self.open(k_i, &kv, commitment)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
+    use bulletproofs_plus::generators::pedersen_gens::ExtensionDegree;
+    use curve25519_dalek::ristretto::RistrettoPoint;
+    use tari_utilities::message_format::MessageFormat;
+
+    use crate::{
+        commitment::ExtendedHomomorphicCommitmentFactory,
+        keys::{PublicKey, SecretKey},
+        ristretto::{
+            constants::RISTRETTO_NUMS_POINTS,
+            pedersen::{
+                extended_commitment_factory::ExtendedPedersenCommitmentFactory,
+                PedersenCommitment,
+                RISTRETTO_PEDERSEN_G,
+                RISTRETTO_PEDERSEN_H,
+            },
+            RistrettoPublicKey,
+            RistrettoSecretKey,
+        },
+    };
+
+    static EXTENSION_DEGREE: [ExtensionDegree; 6] = [
+        ExtensionDegree::Zero,
+        ExtensionDegree::One,
+        ExtensionDegree::Two,
+        ExtensionDegree::Three,
+        ExtensionDegree::Four,
+        ExtensionDegree::Five,
+    ];
+
+    #[test]
+    fn check_default_base() {
+        let factory = ExtendedPedersenCommitmentFactory::default();
+        assert_eq!(factory.0.g_base_vec[0], RISTRETTO_PEDERSEN_G);
+        assert_eq!(factory.0.h_base, *RISTRETTO_PEDERSEN_H);
+        assert_eq!(
+            factory,
+            ExtendedPedersenCommitmentFactory::new_with_extension_degree(ExtensionDegree::Zero).unwrap()
+        );
+    }
+
+    /// Simple test for open for each extension degree:
+    /// - Generate 100 random sets of scalars and calculate the Pedersen commitment for them.
+    /// - Check that the commitment = sum(k_i.G_i) + v.H, and that `open` returns `true` for `open(k_i, v)`
+    #[test]
+    #[allow(non_snake_case)]
+    fn check_open() {
+        let H = *RISTRETTO_PEDERSEN_H;
+        let mut rng = rand::thread_rng();
+        for extension_degree in EXTENSION_DEGREE {
+            let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
+            for _ in 0..25 {
+                let v = RistrettoSecretKey::random(&mut rng);
+                let k_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+                let c = factory.commit(&k_i, &v).unwrap();
+                let mut c_calc: RistrettoPoint = v.0 * H + k_i[0].0 * RISTRETTO_PEDERSEN_G;
+                for i in 1..(extension_degree as usize) {
+                    c_calc += k_i[i].0 * RISTRETTO_NUMS_POINTS[i];
+                }
+                assert_eq!(RistrettoPoint::from(c.as_public_key()), c_calc);
+                assert!(factory.open(&k_i, &v, &c).unwrap());
+                // A different value doesn't open the commitment
+                assert!(!factory.open(&k_i, &(&v + &v), &c).unwrap());
+                // A different blinding factor doesn't open the commitment
+                let mut not_k = k_i;
+                not_k[0] = &not_k[0] + v.clone();
+                assert!(!factory.open(&not_k, &v, &c).unwrap());
+            }
+        }
+    }
+
+    /// Test for random sets of scalars that the homomorphic property holds. i.e.
+    /// $$
+    ///   C = C1 + C2 = sum((k1_i+k2_i).G_i) + (v1+v2).H
+    /// $$
+    /// and
+    /// `open(k1_i+k2_i, v1+v2)` is true for _C_
+    #[test]
+    fn check_homomorphism() {
+        let mut rng = rand::thread_rng();
+        for extension_degree in EXTENSION_DEGREE {
+            for _ in 0..25 {
+                let v1 = RistrettoSecretKey::random(&mut rng);
+                let v2 = RistrettoSecretKey::random(&mut rng);
+                let v_sum = &v1 + &v2;
+                let k1_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+                let k2_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+                let mut k_sum_i = Vec::with_capacity(extension_degree as usize);
+                for i in 0..extension_degree as usize {
+                    k_sum_i.push(&k1_i[i] + &k2_i[i]);
+                }
+                let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
+                let c1 = factory.commit(&k1_i, &v1).unwrap();
+                let c2 = factory.commit(&k2_i, &v2).unwrap();
+                let c_sum = &c1 + &c2;
+                let c_sum2 = factory.commit(&k_sum_i, &v_sum).unwrap();
+                assert!(factory.open(&k1_i, &v1, &c1).unwrap());
+                assert!(factory.open(&k2_i, &v2, &c2).unwrap());
+                assert_eq!(c_sum, c_sum2);
+                assert!(factory.open(&k_sum_i, &v_sum, &c_sum).unwrap());
+            }
+        }
+    }
+
+    /// Test addition of a public key to a homomorphic commitment for extended commitments with`ExtensionDegree::Zero`.
+    /// $$
+    ///   C = C_1 + P = (v1.H + sum(k1_i.G_i)) + sum(k2_i.G_i)) = v1.H + (k1 + sum(k1_i))).G
+    /// $$
+    /// and
+    /// `open(k1+k2, v1)` is true for _C_
+    /// Note: Homomorphism with public key only holds for extended commitments with`ExtensionDegree::Zero`
+    #[test]
+    fn check_homomorphism_with_public_key() {
+        let mut rng = rand::thread_rng();
+        for extension_degree in EXTENSION_DEGREE {
+            // Left-hand side
+            let v1 = RistrettoSecretKey::random(&mut rng);
+            let k1_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+            let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
+            let c1 = factory.commit(&k1_i, &v1).unwrap();
+            let mut k2_i = Vec::with_capacity(extension_degree as usize);
+            let mut k2_pub_i = Vec::with_capacity(extension_degree as usize);
+            for _i in 0..extension_degree as usize {
+                let (k2, k2_pub) = RistrettoPublicKey::random_keypair(&mut rng);
+                k2_i.push(k2);
+                k2_pub_i.push(k2_pub);
+            }
+            let mut c_sum = c1.0;
+            for k2_pub in &k2_pub_i {
+                c_sum = c_sum + k2_pub.clone();
+            }
+            // Right-hand side
+            let mut k_sum_i = Vec::with_capacity(extension_degree as usize);
+            for i in 0..extension_degree as usize {
+                k_sum_i.push(&k1_i[i] + &k2_i[i]);
+            }
+            let c2 = factory.commit(&k_sum_i, &v1).unwrap();
+            // Test
+            assert!(factory.open(&k_sum_i, &v1, &c2).unwrap());
+            match extension_degree {
+                ExtensionDegree::Zero => {
+                    assert_eq!(c_sum, c2.0);
+                },
+                _ => {
+                    assert_ne!(c_sum, c2.0);
+                },
+            }
+        }
+    }
+
+    /// Test addition of individual homomorphic commitments to be equal to a single vector homomorphic commitment for
+    /// extended commitments.
+    /// $$
+    ///   sum(C_j) = sum((v.H + sum(k_i.G_i))_j) = sum(v_j).H + sum(sum(k_i.G_i)_j)
+    /// $$
+    /// and
+    /// `open(sum(sum(k_i)_j), sum(v_j))` is true for `sum(C_j)`
+    /// Note: Homomorphism with public key only holds for extended commitments with`ExtensionDegree::Zero`
+    #[test]
+    fn sum_commitment_vector() {
+        let mut rng = rand::thread_rng();
+        let v_zero = RistrettoSecretKey::default();
+        let k_zero = vec![RistrettoSecretKey::default(); *EXTENSION_DEGREE.iter().max().unwrap() as usize];
+        for extension_degree in EXTENSION_DEGREE {
+            let mut v_sum = RistrettoSecretKey::default();
+            let mut k_sum = vec![RistrettoSecretKey::default(); extension_degree as usize];
+            let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
+            let mut c_sum = factory.commit(&k_zero[0..extension_degree as usize], &v_zero).unwrap();
+            let mut commitments = Vec::with_capacity(25);
+            for _ in 0..25 {
+                let v = RistrettoSecretKey::random(&mut rng);
+                v_sum = &v_sum + &v;
+                let k_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+                for i in 0..extension_degree as usize {
+                    k_sum[i] = &k_sum[i] + &k_i[i];
+                }
+                let c = factory.commit(&k_i, &v).unwrap();
+                c_sum = &c_sum + &c;
+                commitments.push(c);
+            }
+            assert!(factory.open(&k_sum, &v_sum, &c_sum).unwrap());
+            assert_eq!(c_sum, commitments.iter().sum());
+        }
+    }
+
+    #[test]
+    fn serialize_deserialize() {
+        let mut rng = rand::thread_rng();
+        for extension_degree in EXTENSION_DEGREE {
+            let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
+            let k = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+            let c = factory.commit_value(&k, 420).unwrap();
+            // Base64
+            let ser_c = c.to_base64().unwrap();
+            let c2 = PedersenCommitment::from_base64(&ser_c).unwrap();
+            assert!(factory.open_value(&k, 420, &c2).unwrap());
+            // MessagePack
+            let ser_c = c.to_binary().unwrap();
+            let c2 = PedersenCommitment::from_binary(&ser_c).unwrap();
+            assert!(factory.open_value(&k, 420, &c2).unwrap());
+            // Invalid Base64
+            assert!(PedersenCommitment::from_base64("bad@ser$").is_err());
+        }
+    }
+
+    #[test]
+    fn derived_methods() {
+        for extension_degree in EXTENSION_DEGREE {
+            let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
+            let k = vec![RistrettoSecretKey::from(1024); extension_degree as usize];
+            let c1 = factory.commit_value(&k, 2048).unwrap();
+            let mut hasher = DefaultHasher::new();
+            c1.hash(&mut hasher);
+            let c2 = c1.clone();
+            let c3 = factory.commit_value(&k, 2049).unwrap();
+
+            // Test 'clone`
+            assert_eq!(c1, c2);
+            assert_ne!(c2, c3);
+
+            // Note! 'Ord' and 'PartialOrd' are undefined for extended commitments with extension degree other than Zero
+            match extension_degree {
+                ExtensionDegree::Zero => {
+                    // Test 'Debug'
+                    assert_eq!(
+                        format!("{:?}", c1),
+                        "HomomorphicCommitment(9801c7785217e0c973e9b85508c6eebcb74b257a6f825630e17282b81b7fcd78)"
+                    );
+                    // Test hashing
+                    let result = format!("{:x}", hasher.finish());
+                    assert_eq!(&result, "1ef11e8d243c886e");
+                    // test 'Ord' and 'PartialOrd'
+                    assert!(c2 > c3);
+                    assert!(c3 < c2);
+                    assert!(matches!(c2.cmp(&c3), std::cmp::Ordering::Greater));
+                },
+                ExtensionDegree::One => {
+                    // Test 'Debug'
+                    assert_eq!(
+                        format!("{:?}", c1),
+                        "HomomorphicCommitment(42a14804076ba9515be21a519eb1914d3ae1dc3c0237f387bad267a1596c0900)"
+                    );
+                    // Test hashing
+                    let result = format!("{:x}", hasher.finish());
+                    assert_eq!(&result, "77144935b6bfdef2");
+                },
+                ExtensionDegree::Two => {
+                    // Test 'Debug'
+                    assert_eq!(
+                        format!("{:?}", c1),
+                        "HomomorphicCommitment(3232b10a480df84addc7fd9c89ba0225dc586ab907b1ea48e36395dbc1f8013a)"
+                    );
+                    // Test hashing
+                    let result = format!("{:x}", hasher.finish());
+                    assert_eq!(&result, "7d135652dedbd469");
+                },
+                ExtensionDegree::Three => {
+                    // Test 'Debug'
+                    assert_eq!(
+                        format!("{:?}", c1),
+                        "HomomorphicCommitment(128ae4d7b6ee6d441d6ca156e8a0847edd116a5528e65afd0ad7428d2704147d)"
+                    );
+                    // Test hashing
+                    let result = format!("{:x}", hasher.finish());
+                    assert_eq!(&result, "a5015615878d2095");
+                },
+                ExtensionDegree::Four => {
+                    // Test 'Debug'
+                    assert_eq!(
+                        format!("{:?}", c1),
+                        "HomomorphicCommitment(a0f3593cb6a5261e025da8cee5ccd6e102fe365cf544998fd55bb2ec0222f707)"
+                    );
+                    // Test hashing
+                    let result = format!("{:x}", hasher.finish());
+                    assert_eq!(&result, "ea1eb5e67730ac49");
+                },
+                ExtensionDegree::Five => {
+                    // Test 'Debug'
+                    assert_eq!(
+                        format!("{:?}", c1),
+                        "HomomorphicCommitment(7cec35074259cad0b5d3022b29f6e9d5526ed3923d802faffaa64d1829bce67f)"
+                    );
+                    // Test hashing
+                    let result = format!("{:x}", hasher.finish());
+                    assert_eq!(&result, "1a90510f34ef25ed");
+                },
+            }
+        }
+    }
+}

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -58,14 +58,14 @@ impl ExtendedPedersenCommitmentFactory {
                 "Not enough Ristretto NUMS points to construct the extended commitment factory".to_string(),
             ));
         }
-        let mut g_base_vec = Vec::with_capacity(extension_degree as usize);
-        g_base_vec.push(RISTRETTO_PEDERSEN_G);
-        let mut g_base_compressed_vec = Vec::with_capacity(extension_degree as usize);
-        g_base_compressed_vec.push(RISTRETTO_PEDERSEN_G_COMPRESSED);
-        for i in 1..extension_degree as usize {
-            g_base_vec.push(RISTRETTO_NUMS_POINTS[i]);
-            g_base_compressed_vec.push(RISTRETTO_NUMS_POINTS_COMPRESSED[i]);
-        }
+        let g_base_vec = std::iter::once(&RISTRETTO_PEDERSEN_G)
+            .chain(RISTRETTO_NUMS_POINTS[1..extension_degree as usize].iter())
+            .cloned()
+            .collect();
+        let g_base_compressed_vec = std::iter::once(&RISTRETTO_PEDERSEN_G_COMPRESSED)
+            .chain(RISTRETTO_NUMS_POINTS_COMPRESSED[1..extension_degree as usize].iter())
+            .cloned()
+            .collect();
         Ok(Self(PedersenGens {
             h_base: *RISTRETTO_PEDERSEN_H,
             h_base_compressed: *RISTRETTO_PEDERSEN_H_COMPRESSED,
@@ -89,13 +89,13 @@ impl ExtendedHomomorphicCommitmentFactory for ExtendedPedersenCommitmentFactory 
 
     fn commit(
         &self,
-        k_i: &[RistrettoSecretKey],
+        k_vec: &[RistrettoSecretKey],
         v: &RistrettoSecretKey,
     ) -> Result<PedersenCommitment, RangeProofError> {
-        let k_i: Vec<Scalar> = k_i.to_vec().iter().map(|k| k.0).collect();
+        let k_vec: Vec<Scalar> = k_vec.to_vec().iter().map(|k| k.0).collect();
         let c = self
             .0
-            .commit(v.0, &k_i)
+            .commit(v.0, &k_vec)
             .map_err(|e| RangeProofError::ExtensionDegree(e.to_string()))?;
         Ok(HomomorphicCommitment(RistrettoPublicKey::new_from_pk(c)))
     }
@@ -106,29 +106,29 @@ impl ExtendedHomomorphicCommitmentFactory for ExtendedPedersenCommitmentFactory 
 
     fn open(
         &self,
-        k_i: &[RistrettoSecretKey],
+        k_vec: &[RistrettoSecretKey],
         v: &RistrettoSecretKey,
         commitment: &PedersenCommitment,
     ) -> Result<bool, RangeProofError> {
         let c_test = self
-            .commit(k_i, v)
+            .commit(k_vec, v)
             .map_err(|e| RangeProofError::ExtensionDegree(e.to_string()))?;
         Ok(commitment == &c_test)
     }
 
-    fn commit_value(&self, k_i: &[RistrettoSecretKey], value: u64) -> Result<PedersenCommitment, RangeProofError> {
+    fn commit_value(&self, k_vec: &[RistrettoSecretKey], value: u64) -> Result<PedersenCommitment, RangeProofError> {
         let v = RistrettoSecretKey::from(value);
-        self.commit(k_i, &v)
+        self.commit(k_vec, &v)
     }
 
     fn open_value(
         &self,
-        k_i: &[RistrettoSecretKey],
+        k_vec: &[RistrettoSecretKey],
         v: u64,
         commitment: &PedersenCommitment,
     ) -> Result<bool, RangeProofError> {
         let kv = RistrettoSecretKey::from(v);
-        self.open(k_i, &kv, commitment)
+        self.open(k_vec, &kv, commitment)
     }
 }
 
@@ -149,6 +149,7 @@ mod test {
         ristretto::{
             constants::RISTRETTO_NUMS_POINTS,
             pedersen::{
+                commitment_factory::PedersenCommitmentFactory,
                 extended_commitment_factory::ExtendedPedersenCommitmentFactory,
                 PedersenCommitment,
                 RISTRETTO_PEDERSEN_G,
@@ -177,6 +178,20 @@ mod test {
             factory,
             ExtendedPedersenCommitmentFactory::new_with_extension_degree(ExtensionDegree::Zero).unwrap()
         );
+    }
+
+    /// Default bases for PedersenCommitmentFactory and all extension degrees of ExtendedPedersenCommitmentFactory must
+    /// be equal
+    #[test]
+    fn check_extended_bases_between_factories() {
+        let factory_singular = PedersenCommitmentFactory::default();
+        for extension_degree in EXTENSION_DEGREE {
+            let factory_extended =
+                ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
+            assert_eq!(factory_extended.0.extension_degree, extension_degree);
+            assert_eq!(factory_singular.G, factory_extended.0.g_base_vec[0]);
+            assert_eq!(factory_singular.H, factory_extended.0.h_base);
+        }
     }
 
     #[test]
@@ -209,18 +224,18 @@ mod test {
             let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
             for _ in 0..25 {
                 let v = RistrettoSecretKey::random(&mut rng);
-                let k_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
-                let c = factory.commit(&k_i, &v).unwrap();
-                let mut c_calc: RistrettoPoint = v.0 * H + k_i[0].0 * RISTRETTO_PEDERSEN_G;
+                let k_vec = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+                let c = factory.commit(&k_vec, &v).unwrap();
+                let mut c_calc: RistrettoPoint = v.0 * H + k_vec[0].0 * RISTRETTO_PEDERSEN_G;
                 for i in 1..(extension_degree as usize) {
-                    c_calc += k_i[i].0 * RISTRETTO_NUMS_POINTS[i];
+                    c_calc += k_vec[i].0 * RISTRETTO_NUMS_POINTS[i];
                 }
                 assert_eq!(RistrettoPoint::from(c.as_public_key()), c_calc);
-                assert!(factory.open(&k_i, &v, &c).unwrap());
+                assert!(factory.open(&k_vec, &v, &c).unwrap());
                 // A different value doesn't open the commitment
-                assert!(!factory.open(&k_i, &(&v + &v), &c).unwrap());
+                assert!(!factory.open(&k_vec, &(&v + &v), &c).unwrap());
                 // A different blinding factor doesn't open the commitment
-                let mut not_k = k_i;
+                let mut not_k = k_vec;
                 not_k[0] = &not_k[0] + v.clone();
                 assert!(!factory.open(&not_k, &v, &c).unwrap());
             }
@@ -241,19 +256,19 @@ mod test {
                 let v1 = RistrettoSecretKey::random(&mut rng);
                 let v2 = RistrettoSecretKey::random(&mut rng);
                 let v_sum = &v1 + &v2;
-                let k1_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
-                let k2_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+                let k1_vec = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+                let k2_vec = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
                 let mut k_sum_i = Vec::with_capacity(extension_degree as usize);
                 for i in 0..extension_degree as usize {
-                    k_sum_i.push(&k1_i[i] + &k2_i[i]);
+                    k_sum_i.push(&k1_vec[i] + &k2_vec[i]);
                 }
                 let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
-                let c1 = factory.commit(&k1_i, &v1).unwrap();
-                let c2 = factory.commit(&k2_i, &v2).unwrap();
+                let c1 = factory.commit(&k1_vec, &v1).unwrap();
+                let c2 = factory.commit(&k2_vec, &v2).unwrap();
                 let c_sum = &c1 + &c2;
                 let c_sum2 = factory.commit(&k_sum_i, &v_sum).unwrap();
-                assert!(factory.open(&k1_i, &v1, &c1).unwrap());
-                assert!(factory.open(&k2_i, &v2, &c2).unwrap());
+                assert!(factory.open(&k1_vec, &v1, &c1).unwrap());
+                assert!(factory.open(&k2_vec, &v2, &c2).unwrap());
                 assert_eq!(c_sum, c_sum2);
                 assert!(factory.open(&k_sum_i, &v_sum, &c_sum).unwrap());
             }
@@ -273,28 +288,28 @@ mod test {
         for extension_degree in EXTENSION_DEGREE {
             // Left-hand side
             let v1 = RistrettoSecretKey::random(&mut rng);
-            let k1_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+            let k1_vec = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
             let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
-            let c1 = factory.commit(&k1_i, &v1).unwrap();
-            let mut k2_i = Vec::with_capacity(extension_degree as usize);
-            let mut k2_pub_i = Vec::with_capacity(extension_degree as usize);
+            let c1 = factory.commit(&k1_vec, &v1).unwrap();
+            let mut k2_vec = Vec::with_capacity(extension_degree as usize);
+            let mut k2_pub_vec = Vec::with_capacity(extension_degree as usize);
             for _i in 0..extension_degree as usize {
                 let (k2, k2_pub) = RistrettoPublicKey::random_keypair(&mut rng);
-                k2_i.push(k2);
-                k2_pub_i.push(k2_pub);
+                k2_vec.push(k2);
+                k2_pub_vec.push(k2_pub);
             }
             let mut c_sum = c1.0;
-            for k2_pub in &k2_pub_i {
+            for k2_pub in &k2_pub_vec {
                 c_sum = c_sum + k2_pub.clone();
             }
             // Right-hand side
-            let mut k_sum_i = Vec::with_capacity(extension_degree as usize);
+            let mut k_sum_vec = Vec::with_capacity(extension_degree as usize);
             for i in 0..extension_degree as usize {
-                k_sum_i.push(&k1_i[i] + &k2_i[i]);
+                k_sum_vec.push(&k1_vec[i] + &k2_vec[i]);
             }
-            let c2 = factory.commit(&k_sum_i, &v1).unwrap();
+            let c2 = factory.commit(&k_sum_vec, &v1).unwrap();
             // Test
-            assert!(factory.open(&k_sum_i, &v1, &c2).unwrap());
+            assert!(factory.open(&k_sum_vec, &v1, &c2).unwrap());
             match extension_degree {
                 ExtensionDegree::Zero => {
                     assert_eq!(c_sum, c2.0);
@@ -320,22 +335,22 @@ mod test {
         let k_zero = vec![RistrettoSecretKey::default(); ExtensionDegree::Five as usize];
         for extension_degree in EXTENSION_DEGREE {
             let mut v_sum = RistrettoSecretKey::default();
-            let mut k_sum = vec![RistrettoSecretKey::default(); extension_degree as usize];
+            let mut k_sum_vec = vec![RistrettoSecretKey::default(); extension_degree as usize];
             let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
             let mut c_sum = factory.commit(&k_zero[0..extension_degree as usize], &v_zero).unwrap();
             let mut commitments = Vec::with_capacity(25);
             for _ in 0..25 {
                 let v = RistrettoSecretKey::random(&mut rng);
                 v_sum = &v_sum + &v;
-                let k_i = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+                let k_vec = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
                 for i in 0..extension_degree as usize {
-                    k_sum[i] = &k_sum[i] + &k_i[i];
+                    k_sum_vec[i] = &k_sum_vec[i] + &k_vec[i];
                 }
-                let c = factory.commit(&k_i, &v).unwrap();
+                let c = factory.commit(&k_vec, &v).unwrap();
                 c_sum = &c_sum + &c;
                 commitments.push(c);
             }
-            assert!(factory.open(&k_sum, &v_sum, &c_sum).unwrap());
+            assert!(factory.open(&k_sum_vec, &v_sum, &c_sum).unwrap());
             assert_eq!(c_sum, commitments.iter().sum());
         }
     }
@@ -345,16 +360,16 @@ mod test {
         let mut rng = rand::thread_rng();
         for extension_degree in EXTENSION_DEGREE {
             let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
-            let k = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
-            let c = factory.commit_value(&k, 420).unwrap();
+            let k_vec = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
+            let c = factory.commit_value(&k_vec, 420).unwrap();
             // Base64
             let ser_c = c.to_base64().unwrap();
             let c2 = PedersenCommitment::from_base64(&ser_c).unwrap();
-            assert!(factory.open_value(&k, 420, &c2).unwrap());
+            assert!(factory.open_value(&k_vec, 420, &c2).unwrap());
             // MessagePack
             let ser_c = c.to_binary().unwrap();
             let c2 = PedersenCommitment::from_binary(&ser_c).unwrap();
-            assert!(factory.open_value(&k, 420, &c2).unwrap());
+            assert!(factory.open_value(&k_vec, 420, &c2).unwrap());
             // Invalid Base64
             assert!(PedersenCommitment::from_base64("bad@ser$").is_err());
         }
@@ -364,9 +379,9 @@ mod test {
     fn derived_methods() {
         for extension_degree in EXTENSION_DEGREE {
             let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
-            let k = vec![RistrettoSecretKey::from(1024); extension_degree as usize];
+            let k_vec = vec![RistrettoSecretKey::from(1024); extension_degree as usize];
             let value = 2048;
-            let c1 = factory.commit_value(&k, value).unwrap();
+            let c1 = factory.commit_value(&k_vec, value).unwrap();
 
             // Test 'Clone` implementation
             let c2 = c1.clone();
@@ -427,25 +442,33 @@ mod test {
             }
 
             // Test 'Ord' and 'PartialOrd' implementations
-            let mut values = (value - 100..value - 1).collect::<Vec<_>>();
-            values.extend((value + 1..value + 100).collect::<Vec<_>>());
+            let mut values = (value - 10..value).collect::<Vec<_>>();
+            values.extend((value + 1..value + 11).collect::<Vec<_>>());
+            let (mut tested_less_than, mut tested_greater_than) = (false, false);
             for val in values {
-                let c3 = factory.commit_value(&k, val).unwrap();
+                let c3 = factory.commit_value(&k_vec, val).unwrap();
                 assert_ne!(c2, c3);
+                assert_ne!(c2.cmp(&c3), c3.cmp(&c2));
                 if c2 > c3 {
                     assert!(c3 < c2);
+                    assert!(matches!(c2.cmp(&c3), std::cmp::Ordering::Greater));
+                    assert!(matches!(c3.cmp(&c2), std::cmp::Ordering::Less));
+                    tested_less_than = true;
                 }
                 if c2 < c3 {
                     assert!(c3 > c2);
-                }
-                assert_ne!(c2.cmp(&c3), c3.cmp(&c2));
-                if c2.cmp(&c3) == std::cmp::Ordering::Less {
+                    assert!(matches!(c2.cmp(&c3), std::cmp::Ordering::Less));
                     assert!(matches!(c3.cmp(&c2), std::cmp::Ordering::Greater));
+                    tested_greater_than = true;
                 }
-                if c2.cmp(&c3) == std::cmp::Ordering::Greater {
-                    assert!(matches!(c3.cmp(&c2), std::cmp::Ordering::Less));
+                if tested_less_than && tested_greater_than {
+                    break;
                 }
             }
+            assert!(
+                tested_less_than && tested_greater_than,
+                "Try extending the range of values to compare"
+            );
         }
     }
 }

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -285,7 +285,7 @@ mod test {
     fn sum_commitment_vector() {
         let mut rng = rand::thread_rng();
         let v_zero = RistrettoSecretKey::default();
-        let k_zero = vec![RistrettoSecretKey::default(); *EXTENSION_DEGREE.iter().max().unwrap() as usize];
+        let k_zero = vec![RistrettoSecretKey::default(); ExtensionDegree::Five as usize];
         for extension_degree in EXTENSION_DEGREE {
             let mut v_sum = RistrettoSecretKey::default();
             let mut k_sum = vec![RistrettoSecretKey::default(); extension_degree as usize];

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -379,50 +379,50 @@ mod test {
                 ExtensionDegree::Zero => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(601cdc5c97e94bb16ae56f75430f8ab3ef4703c7d89ca9592e8acadc81629f0e)"
+                        "HomomorphicCommitment(f09a7f46c5e3cbadc4c1e84c10278cffab2cb902f7b6f37223c88dd548877a6a)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "699d38210741194e");
+                    assert_eq!(&result, "b1b43e91f6d6109f");
                 },
                 ExtensionDegree::One => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(f0019440ae20b39ba55a88f27ebd7ca56857251beca1047a3b195dc93642d829)"
+                        "HomomorphicCommitment(2486eca30cadb896bc192e53de7d26361b44ddf892ee3e67a6b232483a8e167e)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "fb68d75431b3a0b0");
+                    assert_eq!(&result, "85b6de79a0c73eef");
                 },
                 ExtensionDegree::Two => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(b09789e597115f592491009f18ef4ec13ba7018a77e9df1729f1e2611b237a06)"
+                        "HomomorphicCommitment(9c46efbf4652570045bcd519631aba3e13265a5f75e2b90473b2f556b4a5cc4c)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "61dd716dc29a5fc5");
+                    assert_eq!(&result, "5784c866707a1107");
                 },
                 ExtensionDegree::Three => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(f8356cbea349191683f84818ab5203e48b04fef42f812ddf7d9b92df966c8473)"
+                        "HomomorphicCommitment(4cb95250992c6c71260957403e331d6a7d1f3dd82500699007a2c32b4dff7a23)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "49e988f621628ebc");
+                    assert_eq!(&result, "7b2c5512ec8a20ee");
                 },
                 ExtensionDegree::Four => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(1e113af7e33ac15b328e298239f3796e5061a0863d1a69e297ee8d81ee6e1f22)"
+                        "HomomorphicCommitment(9c877782e158d5fc982ef4cb88a3d3d7eec58f86e55f2e662eacbf6faa6fe21e)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "aff1b9967c7bffe7");
+                    assert_eq!(&result, "bde140256c260df0");
                 },
                 ExtensionDegree::Five => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(126844ee6889dd065ccc0c47e16ea23697f72e6ecce70f5e3fef320d843c332e)"
+                        "HomomorphicCommitment(86384602b8f880c75df5ce0629d5c472ec7d882c00d7de7c5d68463a7a6ec35b)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "e27df20b2dd195ee");
+                    assert_eq!(&result, "88db07fcdaf311d8");
                 },
             }
 

--- a/src/ristretto/pedersen/mod.rs
+++ b/src/ristretto/pedersen/mod.rs
@@ -135,7 +135,8 @@ mod test {
         assert_eq!(factory_singular.H, factory_extended.0.h_base);
     }
 
-    /// Default bases for PedersenCommitmentFactory and all versions of ExtendedPedersenCommitmentFactory must be equal
+    /// Default bases for PedersenCommitmentFactory and all extension degrees of ExtendedPedersenCommitmentFactory must
+    /// be equal
     #[test]
     fn check_extended_bases_between_factories() {
         let factory_singular = PedersenCommitmentFactory::default();
@@ -148,7 +149,8 @@ mod test {
         }
     }
 
-    /// A PedersenCommitmentFactory commitment and ExtendedPedersenCommitmentFactory of degree zero must be equal
+    /// A PedersenCommitmentFactory commitment and ExtendedPedersenCommitmentFactory commitment of degree zero must be
+    /// equal
     #[test]
     fn check_commitments_between_factories() {
         let factory_singular = PedersenCommitmentFactory::default();

--- a/src/ristretto/pedersen/mod.rs
+++ b/src/ristretto/pedersen/mod.rs
@@ -64,7 +64,6 @@ where T: Borrow<PedersenCommitment>
 
 #[cfg(test)]
 mod test {
-    use bulletproofs_plus::generators::pedersen_gens::ExtensionDegree;
     use tari_utilities::ByteArray;
 
     use crate::{
@@ -73,7 +72,7 @@ mod test {
         ristretto::{
             pedersen::{
                 commitment_factory::PedersenCommitmentFactory,
-                extended_commitment_factory::ExtendedPedersenCommitmentFactory,
+                extended_commitment_factory::{ExtendedPedersenCommitmentFactory, ExtensionDegree},
                 PedersenCommitment,
                 RISTRETTO_PEDERSEN_G,
                 RISTRETTO_PEDERSEN_H,
@@ -121,9 +120,9 @@ mod test {
     fn check_default_bases_between_factories() {
         let factory_singular = PedersenCommitmentFactory::default();
         let factory_extended = ExtendedPedersenCommitmentFactory::default();
-        assert_eq!(factory_extended.0.extension_degree, ExtensionDegree::Zero);
-        assert_eq!(factory_singular.G, factory_extended.0.g_base_vec[0]);
-        assert_eq!(factory_singular.H, factory_extended.0.h_base);
+        assert_eq!(factory_extended.extension_degree, ExtensionDegree::DefaultPedersen);
+        assert_eq!(factory_singular.G, factory_extended.g_base_vec[0]);
+        assert_eq!(factory_singular.H, factory_extended.h_base);
     }
 
     /// A PedersenCommitmentFactory commitment and ExtendedPedersenCommitmentFactory commitment of degree zero must be

--- a/src/ristretto/pedersen/mod.rs
+++ b/src/ristretto/pedersen/mod.rs
@@ -1,0 +1,163 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{borrow::Borrow, iter::Sum};
+
+use curve25519_dalek::{
+    constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
+    ristretto::{CompressedRistretto, RistrettoPoint},
+};
+
+use crate::{
+    commitment::HomomorphicCommitment,
+    ristretto::{
+        constants::{RISTRETTO_NUMS_POINTS, RISTRETTO_NUMS_POINTS_COMPRESSED},
+        RistrettoPublicKey,
+    },
+};
+
+pub mod commitment_factory;
+pub mod extended_commitment_factory;
+
+pub const RISTRETTO_PEDERSEN_G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
+pub const RISTRETTO_PEDERSEN_G_COMPRESSED: CompressedRistretto = RISTRETTO_BASEPOINT_COMPRESSED;
+lazy_static! {
+    pub static ref RISTRETTO_PEDERSEN_H: RistrettoPoint = RISTRETTO_NUMS_POINTS[0];
+    pub static ref RISTRETTO_PEDERSEN_H_COMPRESSED: CompressedRistretto = RISTRETTO_NUMS_POINTS_COMPRESSED[0];
+}
+
+pub type PedersenCommitment = HomomorphicCommitment<RistrettoPublicKey>;
+
+impl<T> Sum<T> for PedersenCommitment
+where T: Borrow<PedersenCommitment>
+{
+    fn sum<I>(iter: I) -> Self
+    where I: Iterator<Item = T> {
+        let mut total = RistrettoPoint::default();
+        for c in iter {
+            let commitment = c.borrow();
+            total += RistrettoPoint::from(&commitment.0);
+        }
+        let sum = RistrettoPublicKey::new_from_pk(total);
+        HomomorphicCommitment(sum)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bulletproofs_plus::generators::pedersen_gens::ExtensionDegree;
+    use tari_utilities::ByteArray;
+
+    use crate::{
+        commitment::{ExtendedHomomorphicCommitmentFactory, HomomorphicCommitmentFactory},
+        keys::{PublicKey, SecretKey},
+        ristretto::{
+            pedersen::{
+                commitment_factory::PedersenCommitmentFactory,
+                extended_commitment_factory::ExtendedPedersenCommitmentFactory,
+                PedersenCommitment,
+                RISTRETTO_PEDERSEN_G,
+                RISTRETTO_PEDERSEN_H,
+            },
+            RistrettoPublicKey,
+            RistrettoSecretKey,
+        },
+    };
+
+    static EXTENSION_DEGREE: [ExtensionDegree; 6] = [
+        ExtensionDegree::Zero,
+        ExtensionDegree::One,
+        ExtensionDegree::Two,
+        ExtensionDegree::Three,
+        ExtensionDegree::Four,
+        ExtensionDegree::Five,
+    ];
+
+    #[test]
+    fn pubkey_roundtrip() {
+        let mut rng = rand::thread_rng();
+        let (_, p) = RistrettoPublicKey::random_keypair(&mut rng);
+        let c = PedersenCommitment::from_public_key(&p);
+        assert_eq!(c.as_public_key(), &p);
+        let c2 = PedersenCommitment::from_bytes(c.as_bytes()).unwrap();
+        assert_eq!(c, c2);
+    }
+
+    #[test]
+    fn commitment_sub() {
+        let mut rng = rand::thread_rng();
+        let (_, a) = RistrettoPublicKey::random_keypair(&mut rng);
+        let (_, b) = RistrettoPublicKey::random_keypair(&mut rng);
+        let c = &a + &b;
+        let a = PedersenCommitment::from_public_key(&a);
+        let b = PedersenCommitment::from_public_key(&b);
+        let c = PedersenCommitment::from_public_key(&c);
+        assert_eq!(b, &c - &a);
+    }
+
+    #[test]
+    fn check_g_ne_h() {
+        assert_ne!(RISTRETTO_PEDERSEN_G, *RISTRETTO_PEDERSEN_H);
+    }
+
+    #[test]
+    fn default_value() {
+        let c = PedersenCommitment::default();
+        assert_eq!(c, PedersenCommitment::from_public_key(&RistrettoPublicKey::default()));
+    }
+
+    /// Default bases for PedersenCommitmentFactory and ExtendedPedersenCommitmentFactory must be equal
+    #[test]
+    fn check_default_bases_between_factories() {
+        let factory_singular = PedersenCommitmentFactory::default();
+        let factory_extended = ExtendedPedersenCommitmentFactory::default();
+        assert_eq!(factory_extended.0.extension_degree, ExtensionDegree::Zero);
+        assert_eq!(factory_singular.G, factory_extended.0.g_base_vec[0]);
+        assert_eq!(factory_singular.H, factory_extended.0.h_base);
+    }
+
+    /// Default bases for PedersenCommitmentFactory and all versions of ExtendedPedersenCommitmentFactory must be equal
+    #[test]
+    fn check_extended_bases_between_factories() {
+        let factory_singular = PedersenCommitmentFactory::default();
+        for extension_degree in EXTENSION_DEGREE {
+            let factory_extended =
+                ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
+            assert_eq!(factory_extended.0.extension_degree, extension_degree);
+            assert_eq!(factory_singular.G, factory_extended.0.g_base_vec[0]);
+            assert_eq!(factory_singular.H, factory_extended.0.h_base);
+        }
+    }
+
+    /// A PedersenCommitmentFactory commitment and ExtendedPedersenCommitmentFactory of degree zero must be equal
+    #[test]
+    fn check_commitments_between_factories() {
+        let factory_singular = PedersenCommitmentFactory::default();
+        let factory_extended = ExtendedPedersenCommitmentFactory::default();
+        let mut rng = rand::thread_rng();
+        let v = RistrettoSecretKey::random(&mut rng);
+        let k = RistrettoSecretKey::random(&mut rng);
+        let c_singular = factory_singular.commit(&k, &v);
+        let c_extended = factory_extended.commit(&[k], &v).unwrap();
+        assert_eq!(c_singular, c_extended);
+    }
+}

--- a/src/ristretto/pedersen/mod.rs
+++ b/src/ristretto/pedersen/mod.rs
@@ -83,15 +83,6 @@ mod test {
         },
     };
 
-    static EXTENSION_DEGREE: [ExtensionDegree; 6] = [
-        ExtensionDegree::Zero,
-        ExtensionDegree::One,
-        ExtensionDegree::Two,
-        ExtensionDegree::Three,
-        ExtensionDegree::Four,
-        ExtensionDegree::Five,
-    ];
-
     #[test]
     fn pubkey_roundtrip() {
         let mut rng = rand::thread_rng();
@@ -133,20 +124,6 @@ mod test {
         assert_eq!(factory_extended.0.extension_degree, ExtensionDegree::Zero);
         assert_eq!(factory_singular.G, factory_extended.0.g_base_vec[0]);
         assert_eq!(factory_singular.H, factory_extended.0.h_base);
-    }
-
-    /// Default bases for PedersenCommitmentFactory and all extension degrees of ExtendedPedersenCommitmentFactory must
-    /// be equal
-    #[test]
-    fn check_extended_bases_between_factories() {
-        let factory_singular = PedersenCommitmentFactory::default();
-        for extension_degree in EXTENSION_DEGREE {
-            let factory_extended =
-                ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
-            assert_eq!(factory_extended.0.extension_degree, extension_degree);
-            assert_eq!(factory_singular.G, factory_extended.0.g_base_vec[0]);
-            assert_eq!(factory_singular.H, factory_extended.0.h_base);
-        }
     }
 
     /// A PedersenCommitmentFactory commitment and ExtendedPedersenCommitmentFactory commitment of degree zero must be

--- a/src/ristretto/pedersen/mod.rs
+++ b/src/ristretto/pedersen/mod.rs
@@ -136,7 +136,7 @@ mod test {
         let v = RistrettoSecretKey::random(&mut rng);
         let k = RistrettoSecretKey::random(&mut rng);
         let c_singular = factory_singular.commit(&k, &v);
-        let c_extended = factory_extended.commit(&[k], &v).unwrap();
+        let c_extended = factory_extended.commit_extended(&[k], &v).unwrap();
         assert_eq!(c_singular, c_extended);
     }
 }

--- a/src/ristretto/ristretto_com_sig.rs
+++ b/src/ristretto/ristretto_com_sig.rs
@@ -92,11 +92,11 @@ use crate::{
 /// use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
 ///
 /// let commitment =
-///     HomomorphicCommitment::from_hex("167c6df11bf8106e89328c297e57423dc2a9be53df1ee63f6e50b4610104ab4a").unwrap();
+///     HomomorphicCommitment::from_hex("d6cca5cc4cc302c1854a118221d6cf64d100b7da76665dae5199368f3703c665").unwrap();
 /// let r_nonce =
-///     HomomorphicCommitment::from_hex("4033e00996e61df2ea1abd1494b751b946663e21a20e2729c6592712beb15356").unwrap();
-/// let u = RistrettoSecretKey::from_hex("f44bbc3374b172f77ffa8b904ddf0ad9f879b3e6183f9e440c57e7f01e851300").unwrap();
-/// let v = RistrettoSecretKey::from_hex("fd54afb2d8008c8a3af10272b24161247b2b7ae11687813fe9fb03e34dd7f009").unwrap();
+///     HomomorphicCommitment::from_hex("9607f72d84d704825864a4455c2325509ecc290eb9419bbce7ff05f1f578284c").unwrap();
+/// let u = RistrettoSecretKey::from_hex("0fd60e6479507fec35a46d2ec9da0ae300e9202e613e99b8f2b01d7ef6eccc02").unwrap();
+/// let v = RistrettoSecretKey::from_hex("9ae6621dd99ecc252b90a0eb69577c6f3d2e1e8abcdd43bfd0297afadf95fb0b").unwrap();
 /// let sig = RistrettoComSig::new(r_nonce, u, v);
 /// let e = Blake256::digest(b"Maskerade");
 /// let factory = PedersenCommitmentFactory::default();

--- a/src/ristretto/ristretto_com_sig.rs
+++ b/src/ristretto/ristretto_com_sig.rs
@@ -58,6 +58,8 @@ use crate::{
 /// # use digest::Digest;
 /// # use tari_crypto::commitment::HomomorphicCommitmentFactory;
 /// # use tari_crypto::ristretto::pedersen::*;
+/// use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
+/// use tari_utilities::hex::Hex;
 ///
 /// let mut rng = rand::thread_rng();
 /// let a_val = RistrettoSecretKey::random(&mut rng);
@@ -67,7 +69,9 @@ use crate::{
 /// let e = Blake256::digest(b"Maskerade");
 /// let factory = PedersenCommitmentFactory::default();
 /// let commitment = factory.commit(&x_val, &a_val);
+/// // println!("commitment: {:?}", commitment.to_hex());
 /// let sig = RistrettoComSig::sign(&a_val, &x_val, &a_nonce, &x_nonce, &e, &factory).unwrap();
+/// // println!("sig: R {:?} u {:?} v {:?}", sig.public_nonce().to_hex(), sig.u().to_hex(), sig.v().to_hex());
 /// assert!(sig.verify_challenge(&commitment, &e, &factory));
 /// ```
 ///
@@ -85,13 +89,14 @@ use crate::{
 /// # use tari_utilities::hex::*;
 /// # use tari_utilities::ByteArray;
 /// # use digest::Digest;
+/// use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
 ///
 /// let commitment =
-///     HomomorphicCommitment::from_hex("d6cca5cc4cc302c1854a118221d6cf64d100b7da76665dae5199368f3703c665").unwrap();
+///     HomomorphicCommitment::from_hex("c4c38e10ee55f7fd66bee579b9f5dd8ec63f5857400ca4b2d5772cf69094c70d").unwrap();
 /// let r_nonce =
-///     HomomorphicCommitment::from_hex("9607f72d84d704825864a4455c2325509ecc290eb9419bbce7ff05f1f578284c").unwrap();
-/// let u = RistrettoSecretKey::from_hex("0fd60e6479507fec35a46d2ec9da0ae300e9202e613e99b8f2b01d7ef6eccc02").unwrap();
-/// let v = RistrettoSecretKey::from_hex("9ae6621dd99ecc252b90a0eb69577c6f3d2e1e8abcdd43bfd0297afadf95fb0b").unwrap();
+///     HomomorphicCommitment::from_hex("f8852ddda5856305fa1f4ecd116958f9904c95d6506e0096207199672b7c1051").unwrap();
+/// let u = RistrettoSecretKey::from_hex("37766058ffdafd9720b93f7b6d30648b8b4765282303b088999e2f6ef9761e06").unwrap();
+/// let v = RistrettoSecretKey::from_hex("45c881f1650490112397c0ff9a06803a93f846aadc9dd9c27911e98f3a5d350f").unwrap();
 /// let sig = RistrettoComSig::new(r_nonce, u, v);
 /// let e = Blake256::digest(b"Maskerade");
 /// let factory = PedersenCommitmentFactory::default();
@@ -109,7 +114,7 @@ mod test {
         common::Blake256,
         keys::{PublicKey, SecretKey},
         ristretto::{
-            pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+            pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
             RistrettoComSig,
             RistrettoPublicKey,
             RistrettoSecretKey,

--- a/src/ristretto/ristretto_com_sig.rs
+++ b/src/ristretto/ristretto_com_sig.rs
@@ -92,11 +92,11 @@ use crate::{
 /// use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
 ///
 /// let commitment =
-///     HomomorphicCommitment::from_hex("c4c38e10ee55f7fd66bee579b9f5dd8ec63f5857400ca4b2d5772cf69094c70d").unwrap();
+///     HomomorphicCommitment::from_hex("167c6df11bf8106e89328c297e57423dc2a9be53df1ee63f6e50b4610104ab4a").unwrap();
 /// let r_nonce =
-///     HomomorphicCommitment::from_hex("f8852ddda5856305fa1f4ecd116958f9904c95d6506e0096207199672b7c1051").unwrap();
-/// let u = RistrettoSecretKey::from_hex("37766058ffdafd9720b93f7b6d30648b8b4765282303b088999e2f6ef9761e06").unwrap();
-/// let v = RistrettoSecretKey::from_hex("45c881f1650490112397c0ff9a06803a93f846aadc9dd9c27911e98f3a5d350f").unwrap();
+///     HomomorphicCommitment::from_hex("4033e00996e61df2ea1abd1494b751b946663e21a20e2729c6592712beb15356").unwrap();
+/// let u = RistrettoSecretKey::from_hex("f44bbc3374b172f77ffa8b904ddf0ad9f879b3e6183f9e440c57e7f01e851300").unwrap();
+/// let v = RistrettoSecretKey::from_hex("fd54afb2d8008c8a3af10272b24161247b2b7ae11687813fe9fb03e34dd7f009").unwrap();
 /// let sig = RistrettoComSig::new(r_nonce, u, v);
 /// let e = Blake256::digest(b"Maskerade");
 /// let factory = PedersenCommitmentFactory::default();

--- a/src/wasm/commitments.rs
+++ b/src/wasm/commitments.rs
@@ -27,7 +27,7 @@ use wasm_bindgen::prelude::*;
 use crate::{
     commitment::HomomorphicCommitmentFactory,
     ristretto::{
-        pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
         RistrettoPublicKey,
         RistrettoSecretKey,
     },

--- a/src/wasm/key_utils.rs
+++ b/src/wasm/key_utils.rs
@@ -34,7 +34,7 @@ use crate::{
     common::Blake256,
     keys::{PublicKey, SecretKey},
     ristretto::{
-        pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
         RistrettoComSig,
         RistrettoPublicKey,
         RistrettoSchnorr,

--- a/src/wasm/keyring.rs
+++ b/src/wasm/keyring.rs
@@ -30,7 +30,7 @@ use crate::{
     commitment::HomomorphicCommitmentFactory,
     keys::PublicKey,
     ristretto::{
-        pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
         RistrettoPublicKey,
         RistrettoSecretKey,
     },

--- a/src/wasm/range_proofs.rs
+++ b/src/wasm/range_proofs.rs
@@ -28,7 +28,7 @@ use crate::{
     range_proof::RangeProofService,
     ristretto::{
         dalek_range_proof::DalekRangeProofService,
-        pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
         RistrettoSecretKey,
     },
     tari_utilities::hex::from_hex,


### PR DESCRIPTION
Added extended ristretto commitment factory for Pedersen commitments making use of the extended Pedersen generators in the Tari Bulletproofs+ library.

Notes:
- `RISTRETTO_NUMS_POINTS` have been updated by sequentially hashing the domain separated Ristretto255 generator point instead of sequentially hashing the generator point only. Domain separated hashing is less likely to result in unintended collisions or reuse elsewhere.
- An `ExtendedHomomorphicCommitmentFactory` trait has been added
- `ristretto/pedersen` has been changed into a module that defines `pedersen/commitment_factory` and `pedersen/extended_commitment_factory`
- `PedersenCommitmentFactory` and `ExtendedPedersenCommitmentFactory` use the same base `G` and `H` generator points so that each factory produces the same commitments for their default implementation.
- For `ExtendedPedersenCommitmentFactory`:
  - Homomorphism with public key only holds for extended commitments with `ExtensionDegree::Zero`
  - ~'Ord' and 'PartialOrd' are undefined for extended commitments other than `ExtensionDegree::Zero`~
- _**Update**: The common interface trait `HomomorphicCommitmentFactory` has also been implemented for `ExtendedPedersenCommitmentFactory` so that its default invocation is compatible with all methods of `PedersenCommitmentFactory`._
- 
_The next PR will include the `ExtendedRangeProofService` trait and `BulletProofsPlusService`._