### PR TITLE
chore: upgrade tari_utilities version to 0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.13.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.3" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.4" }
 
 base64 = "0.10.1"
 blake2 = "0.9.1"


### PR DESCRIPTION
The upgrade of the `tari_utilities` crate to `0.4.4` version.