### PR TITLE
chore: revert 'curve25519-dalek'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 
 base64 = "0.10.1"
 blake2 = "0.9.1"
-bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", tag = "v4.2.0" }
-bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", tag = "v0.0.5" }
-curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2", default-features = false, features = ["serde", "alloc"] }
+bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", commit = "0033c45538164eb1d81891dad054e217d8b364f4" }
+bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", commit = "28725cdd7d753478c9508cae629a8063fc46be37" }
+curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["u64_backend", "serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }
 lazy_static = "1.3.0"
@@ -30,7 +30,7 @@ serde_json = "1.0"
 sha3 = "0.9"
 thiserror = "1.0.20"
 wasm-bindgen = { version = "^0.2", features = ["serde-serialize"], optional = true }
-zeroize = "1.0.0"
+zeroize = "1.4.0"
 
 [dev-dependencies]
 bincode = "1.1.4"

--- a/src/extended_range_proof.rs
+++ b/src/extended_range_proof.rs
@@ -32,10 +32,10 @@ pub trait ExtendedRangeProofService {
     type PK: PublicKey<K = Self::K>;
 
     /// Constructs a new extended range proof, which may be aggregated, for the given set(s) of secret key(s) value(s)
-    /// and optional minimum value promise(s). Other optional inputs are seed nonce(s) and mask(s) for mask embedding
+    /// and minimum value promise(s). Other optional inputs are seed nonce(s) and mask(s) for mask embedding
     /// and recovery. If no mask(s) are provided together with the seed nonce(s), the secret key(s), will be embedded.
     /// The resulting (aggregated) extended proof will be sufficient evidence that the prover knows the set(s) of
-    /// secret key(s) and value(s), and that each value is equal to or greater than zero or its optional minimum value
+    /// secret key(s) and value(s), and that each value is equal to or greater than zero or its minimum value
     /// promise and lies in the range determined by the service.
     fn construct_extended_proof(
         &self,
@@ -58,7 +58,7 @@ pub trait ExtendedRangeProofService {
         statements: Vec<&AggregatedPrivateStatement<Self::PK>>,
     ) -> Result<Vec<Option<ExtendedMask<Self::K>>>, RangeProofError>;
 
-    /// Verify the batch of range proofs against the given commitments and optional minimum value promises. If this
+    /// Verify the batch of range proofs against the given commitments and minimum value promises. If this
     /// function returns Ok, it attests to the batch of commitments having values in the range [min_val_promise; 2^64-1]
     /// and that the provers knew both the values and private keys for those commitments.
     fn verify_batch(
@@ -112,7 +112,7 @@ where K: SecretKey
     }
 }
 
-/// The (public) statement contains the commitment and an optional minimum promised value
+/// The (public) statement contains the commitment and a minimum promised value
 #[derive(Clone)]
 pub struct Statement<PK>
 where PK: PublicKey
@@ -123,7 +123,7 @@ where PK: PublicKey
     pub minimum_value_promise: u64,
 }
 
-/// The aggregated public range proof statement contains the vector of commitments and a vector of optional minimum
+/// The aggregated public range proof statement contains the vector of commitments and a vector of minimum
 /// promised values
 #[derive(Clone)]
 pub struct AggregatedPublicStatement<PK>
@@ -154,7 +154,7 @@ where PK: PublicKey
 pub struct AggregatedPrivateStatement<PK>
 where PK: PublicKey
 {
-    /// The aggregated commitments and optional minimum promised values
+    /// The aggregated commitments and minimum promised values
     pub statements: Vec<Statement<PK>>,
     /// Optional private seed nonce for mask recovery
     pub recovery_seed_nonce: Option<PK::K>,
@@ -184,7 +184,7 @@ where PK: PublicKey
     }
 }
 
-/// The extended witness contains the extended mask (blinding factor vector), value and an optional minimum value
+/// The extended witness contains the extended mask (blinding factor vector), value and a minimum value
 /// promise; this will be used to construct the extended range proof
 #[derive(Clone)]
 pub struct ExtendedWitness<K>


### PR DESCRIPTION
Using `curve25519-dalek = { package = "curve25519-dalek-ng", version= "4.1"`
instead of `curve25519-dalek = { package = "curve25519-dalek", version = "4.0.0-pre.2"`
due to issues with `zeroize`