### PR TITLE
chore: add bp and bp+ tags to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 
 base64 = "0.10.1"
 blake2 = "0.9.1"
-bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", rev = "0033c45538164eb1d81891dad054e217d8b364f4" }
-bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", rev = "28725cdd7d753478c9508cae629a8063fc46be37" }
+bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", tag = "v4.2.1" }
+bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", tag = "v0.0.6" }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["u64_backend", "serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }

--- a/src/wasm/range_proofs.rs
+++ b/src/wasm/range_proofs.rs
@@ -60,17 +60,17 @@ pub struct RecoverResult {
 
 #[wasm_bindgen]
 pub struct RangeProofFactory {
-    rpf: DalekRangeProofService,
-    //    cf: PedersenCommitmentFactory,
+    range_proof_service: DalekRangeProofService,
+    //    factory: PedersenCommitmentFactory,
 }
 
 #[wasm_bindgen]
 impl RangeProofFactory {
     /// Create a new `RangeProofFactory`
     pub fn new() -> Self {
-        let cf = PedersenCommitmentFactory::default();
-        let rpf = DalekRangeProofService::new(64, &cf).unwrap();
-        RangeProofFactory { rpf }
+        let factory = PedersenCommitmentFactory::default();
+        let range_proof_service = DalekRangeProofService::new(64, &factory).unwrap();
+        RangeProofFactory { range_proof_service }
     }
 
     /// Creates a new range proof for the given key-value pair.
@@ -83,7 +83,7 @@ impl RangeProofFactory {
                 return JsValue::from_serde(&result).unwrap();
             },
         };
-        match self.rpf.construct_proof(&key, value) {
+        match self.range_proof_service.construct_proof(&key, value) {
             Ok(p) => result.proof = p.to_hex(),
             Err(e) => result.error = e.to_string(),
         };
@@ -107,7 +107,7 @@ impl RangeProofFactory {
                 return JsValue::from_serde(&result).unwrap();
             },
         };
-        result.valid = self.rpf.verify(&proof, &commitment);
+        result.valid = self.range_proof_service.verify(&proof, &commitment);
         JsValue::from_serde(&result).unwrap()
     }
 }
@@ -120,16 +120,16 @@ impl Default for RangeProofFactory {
 
 #[wasm_bindgen]
 pub struct ExtendedRangeProofFactory {
-    rpf: BulletproofsPlusService,
+    range_proof_service: BulletproofsPlusService,
 }
 
 #[wasm_bindgen]
 impl ExtendedRangeProofFactory {
     /// Create a new `RangeProofFactory`
     pub fn new() -> Self {
-        let cf = ExtendedPedersenCommitmentFactory::default();
-        let rpf = BulletproofsPlusService::init(64, 1, cf).unwrap();
-        ExtendedRangeProofFactory { rpf }
+        let factory = ExtendedPedersenCommitmentFactory::default();
+        let range_proof_service = BulletproofsPlusService::init(64, 1, factory).unwrap();
+        ExtendedRangeProofFactory { range_proof_service }
     }
 
     /// Creates a new range proof for the given key-value pair.
@@ -142,7 +142,7 @@ impl ExtendedRangeProofFactory {
                 return JsValue::from_serde(&result).unwrap();
             },
         };
-        match self.rpf.construct_proof(&key, value) {
+        match self.range_proof_service.construct_proof(&key, value) {
             Ok(p) => result.proof = p.to_hex(),
             Err(e) => result.error = e.to_string(),
         };
@@ -166,7 +166,7 @@ impl ExtendedRangeProofFactory {
                 return JsValue::from_serde(&result).unwrap();
             },
         };
-        result.valid = self.rpf.verify(&proof, &commitment);
+        result.valid = self.range_proof_service.verify(&proof, &commitment);
         JsValue::from_serde(&result).unwrap()
     }
 
@@ -187,7 +187,7 @@ impl ExtendedRangeProofFactory {
             },
         };
         match self
-            .rpf
+            .range_proof_service
             .construct_proof_with_recovery_seed_nonce(&mask, value, &seed_nonce)
         {
             Ok(p) => result.proof = p.to_hex(),
@@ -219,7 +219,7 @@ impl ExtendedRangeProofFactory {
                 return JsValue::from_serde(&result).unwrap();
             },
         };
-        match self.rpf.recover_mask(&proof, &commitment, &seed_nonce) {
+        match self.range_proof_service.recover_mask(&proof, &commitment, &seed_nonce) {
             Ok(p) => result.mask = p.to_hex(),
             Err(e) => result.error = e.to_string(),
         };
@@ -242,7 +242,7 @@ impl ExtendedRangeProofFactory {
                 return JsValue::from_serde(&result).unwrap();
             },
         };
-        match self.rpf.verify_mask(&commitment, &mask, value) {
+        match self.range_proof_service.verify_mask(&commitment, &mask, value) {
             Ok(p) => result.valid = p,
             Err(e) => result.error = e.to_string(),
         };
@@ -275,13 +275,15 @@ mod test {
     #[wasm_bindgen_test]
     fn dalek_range_proof_creates_a_valid_proof() {
         let factory = RangeProofFactory::new();
-        let (sk, _) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let (blinding_factor, _) = RistrettoPublicKey::random_keypair(&mut OsRng);
         let result = factory
-            .create_proof(&sk.to_hex(), 123)
+            .create_proof(&blinding_factor.to_hex(), 123)
             .into_serde::<RangeProofResult>()
             .unwrap();
-        let commitment = PedersenCommitmentFactory::default().commit_value(&sk, 123);
-        assert!(factory.rpf.verify(&from_hex(&result.proof).unwrap(), &commitment));
+        let commitment = PedersenCommitmentFactory::default().commit_value(&blinding_factor, 123);
+        assert!(factory
+            .range_proof_service
+            .verify(&from_hex(&result.proof).unwrap(), &commitment));
         let result = factory
             .verify(&commitment.to_hex(), &result.proof)
             .into_serde::<VerificationResult>()
@@ -300,13 +302,13 @@ mod test {
     #[wasm_bindgen_test]
     fn bulletproof_plus_creates_a_valid_proof() {
         let factory = ExtendedRangeProofFactory::new();
-        let (sk, _) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let (blinding_factor, _) = RistrettoPublicKey::random_keypair(&mut OsRng);
         let value = 123;
-        let commitment = ExtendedPedersenCommitmentFactory::default().commit_value(&sk, value);
+        let commitment = ExtendedPedersenCommitmentFactory::default().commit_value(&blinding_factor, value);
 
         // Non-rewindable range proof
         let proof_result = factory
-            .create_proof(&sk.to_hex(), value)
+            .create_proof(&blinding_factor.to_hex(), value)
             .into_serde::<RangeProofResult>()
             .unwrap();
         let proof_verification_result = factory
@@ -319,10 +321,12 @@ mod test {
         // - Create
         let (seed_nonce, _) = RistrettoPublicKey::random_keypair(&mut OsRng);
         let proof_result = factory
-            .construct_proof_with_recovery_seed_nonce(&sk.to_hex(), value, &seed_nonce.to_hex())
+            .construct_proof_with_recovery_seed_nonce(&blinding_factor.to_hex(), value, &seed_nonce.to_hex())
             .into_serde::<RangeProofResult>()
             .unwrap();
-        assert!(factory.rpf.verify(&from_hex(&proof_result.proof).unwrap(), &commitment));
+        assert!(factory
+            .range_proof_service
+            .verify(&from_hex(&proof_result.proof).unwrap(), &commitment));
         // - Recover the blinding factor (mask)
         let recover_result = factory
             .recover_mask(&proof_result.proof, &commitment.to_hex(), &seed_nonce.to_hex())
@@ -336,7 +340,7 @@ mod test {
 
         // To print to `console.log`:
         // use crate::wasm::range_proofs::test::__rt::log;
-        // log(&format_args!("blinding_factor: {}", &sk.to_hex()));
+        // log(&format_args!("blinding_factor: {}", &blinding_factor.to_hex()));
         // log(&format_args!("mask           : {}", &recover_result.mask));
     }
 }


### PR DESCRIPTION
- Updated ` cargo.toml` with proper tags for `tari_bulletproofs` and `tari_bulletproofs_plus`
- Improved some naming in wasm bindings