### PR TITLE
feat!: change to nums constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["cryptography"]
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.13.2"
+version = "0.13.4"
 edition = "2018"
 
 [dependencies]

--- a/src/ristretto/constants.rs
+++ b/src/ristretto/constants.rs
@@ -22,49 +22,50 @@
 
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 
-/// These points on the Ristretto curve have been created by sequentially hashing the Generator point with SHA512 and
-/// using the byte string representation of the hash as input into the `from_uniform_bytes` constructor in
-/// [RistrettoPoint](Struct.RistrettoPoint.html). This process is validated with the `check_nums_points` test below.
+/// These points on the Ristretto curve have been created by hashing domain separation labels with SHA512 and converting
+/// the hash output to a Ristretto generator point by using the byte string representation of the hash as input into the
+/// `from_uniform_bytes` constructor in [RistrettoPoint](Struct.RistrettoPoint.html). This process is validated with the
+/// `check_nums_points` test below.
 pub const RISTRETTO_NUMS_POINTS_COMPRESSED: [CompressedRistretto; 10] = [
     CompressedRistretto([
-        144, 202, 17, 205, 108, 98, 39, 203, 10, 188, 57, 226, 113, 12, 68, 74, 230, 97, 126, 168, 24, 152, 231, 22,
-        53, 63, 52, 16, 217, 101, 102, 5,
+        206, 56, 152, 65, 192, 200, 105, 138, 185, 91, 112, 36, 42, 238, 166, 72, 64, 177, 234, 197, 246, 68, 183, 208,
+        8, 172, 5, 135, 207, 71, 29, 112,
     ]),
     CompressedRistretto([
-        158, 163, 67, 196, 112, 228, 87, 33, 101, 243, 64, 56, 81, 223, 107, 32, 221, 251, 206, 241, 171, 132, 207,
-        171, 15, 197, 139, 223, 124, 54, 254, 7,
+        54, 179, 59, 85, 148, 85, 113, 114, 237, 39, 200, 19, 236, 249, 193, 45, 13, 194, 254, 236, 39, 225, 9, 66,
+        123, 41, 222, 21, 125, 254, 102, 77,
     ]),
     CompressedRistretto([
-        48, 188, 62, 20, 154, 63, 125, 42, 172, 191, 231, 48, 225, 158, 154, 7, 119, 59, 83, 83, 219, 98, 32, 99, 185,
-        44, 153, 54, 50, 173, 60, 7,
+        152, 202, 159, 30, 58, 170, 77, 68, 126, 51, 86, 197, 114, 69, 19, 227, 202, 190, 145, 71, 127, 19, 101, 207,
+        17, 221, 227, 175, 5, 88, 90, 85,
     ]),
     CompressedRistretto([
-        142, 16, 136, 206, 212, 150, 29, 136, 213, 177, 113, 189, 154, 52, 40, 68, 84, 120, 154, 69, 95, 70, 236, 55,
-        82, 145, 49, 33, 36, 183, 30, 108,
+        242, 2, 148, 178, 187, 151, 148, 185, 122, 161, 129, 17, 83, 85, 124, 125, 30, 139, 225, 50, 69, 73, 206, 68,
+        114, 177, 81, 20, 255, 56, 82, 71,
     ]),
     CompressedRistretto([
-        112, 19, 255, 145, 136, 246, 135, 216, 133, 201, 90, 218, 110, 88, 11, 35, 141, 231, 33, 12, 85, 193, 246, 36,
-        123, 31, 16, 101, 38, 8, 10, 85,
+        196, 93, 153, 124, 195, 94, 29, 16, 123, 234, 15, 2, 184, 227, 67, 128, 103, 87, 113, 86, 69, 132, 187, 122,
+        11, 194, 246, 23, 111, 190, 164, 28,
     ]),
     CompressedRistretto([
-        122, 234, 197, 53, 77, 120, 8, 171, 35, 80, 105, 62, 45, 2, 30, 42, 99, 188, 47, 231, 194, 119, 210, 5, 107,
-        176, 108, 127, 141, 78, 6, 81,
+        70, 122, 19, 104, 23, 41, 249, 95, 206, 125, 54, 95, 126, 136, 57, 94, 54, 200, 73, 141, 40, 206, 124, 156,
+        224, 237, 133, 95, 3, 225, 220, 102,
     ]),
     CompressedRistretto([
-        228, 224, 63, 227, 33, 214, 87, 20, 172, 223, 193, 247, 88, 37, 111, 121, 204, 69, 49, 213, 30, 143, 121, 244,
-        15, 194, 105, 198, 196, 117, 160, 65,
+        212, 243, 209, 88, 16, 127, 237, 87, 22, 162, 111, 122, 214, 165, 70, 23, 71, 139, 35, 16, 187, 144, 228, 5,
+        182, 51, 244, 148, 184, 63, 222, 26,
     ]),
     CompressedRistretto([
-        136, 214, 134, 144, 253, 111, 238, 89, 110, 128, 92, 250, 34, 30, 126, 40, 119, 21, 166, 201, 46, 148, 100,
-        255, 196, 32, 172, 183, 12, 236, 51, 27,
+        106, 114, 88, 57, 144, 221, 187, 75, 248, 13, 1, 136, 214, 61, 106, 235, 221, 175, 66, 184, 107, 31, 113, 2,
+        142, 36, 210, 62, 91, 35, 45, 25,
     ]),
     CompressedRistretto([
-        204, 102, 24, 189, 15, 12, 192, 35, 132, 29, 173, 74, 19, 204, 46, 55, 166, 35, 14, 36, 48, 80, 214, 220, 196,
-        201, 49, 208, 70, 224, 234, 3,
+        206, 164, 160, 199, 62, 109, 174, 203, 69, 222, 211, 23, 80, 44, 161, 143, 118, 138, 145, 140, 51, 145, 84,
+        208, 173, 74, 97, 128, 193, 239, 30, 30,
     ]),
     CompressedRistretto([
-        96, 230, 255, 101, 87, 7, 198, 66, 73, 210, 250, 146, 78, 49, 146, 182, 149, 220, 88, 44, 180, 246, 214, 140,
-        180, 43, 155, 49, 24, 147, 237, 64,
+        218, 174, 170, 84, 178, 150, 240, 77, 72, 189, 188, 156, 46, 84, 202, 209, 80, 14, 212, 160, 195, 106, 149, 59,
+        173, 24, 184, 4, 233, 38, 232, 44,
     ]),
 ];
 
@@ -89,21 +90,21 @@ mod test {
 
     use crate::ristretto::constants::{RISTRETTO_NUMS_POINTS, RISTRETTO_NUMS_POINTS_COMPRESSED};
 
-    /// Generate a set of NUMS points by sequentially hashing the Ristretto255 generator point. By using
-    /// `from_uniform_bytes`, the resulting point is a NUMS point if the input bytes are from a uniform distribution.
+    /// Generate a set of NUMS points by hashing domain separation labels and converting the hash output to a Ristretto
+    /// generator point. By using `RistrettoPoint::from_uniform_bytes`, the resulting point is a NUMS point if the input
+    /// bytes are from a uniform distribution.
     fn nums_ristretto(n: usize) -> (Vec<RistrettoPoint>, Vec<CompressedRistretto>) {
-        let mut val = RISTRETTO_BASEPOINT_POINT.compress().to_bytes();
         let mut points = Vec::with_capacity(n);
         let mut compressed_points = Vec::with_capacity(n);
         let mut a: [u8; 64] = [0; 64];
-        for _ in 0..n {
-            let hashed_v = Sha512::digest(&val[..]);
+        for i in 0..n {
+            let mut data = b"TARI CRYPTO NUMS BASEPOINT LABEL - ".to_vec(); // Domain label
+            data.append(&mut i.to_le_bytes().to_vec()); // Append domain separated label counter
+            let hashed_v = Sha512::digest(&*data);
             a.copy_from_slice(&hashed_v);
             let next_val = RistrettoPoint::from_uniform_bytes(&a);
             points.push(next_val);
-            let next_compressed = next_val.compress();
-            val = next_compressed.to_bytes();
-            compressed_points.push(next_compressed);
+            compressed_points.push(next_val.compress());
         }
         (points, compressed_points)
     }

--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -255,7 +255,7 @@ mod test {
         // Test 'Debug' implementation
         assert_eq!(
             format!("{:?}", c1),
-            "HomomorphicCommitment(f09a7f46c5e3cbadc4c1e84c10278cffab2cb902f7b6f37223c88dd548877a6a)"
+            "HomomorphicCommitment(601cdc5c97e94bb16ae56f75430f8ab3ef4703c7d89ca9592e8acadc81629f0e)"
         );
         // Test 'Clone' implementation
         let c2 = c1.clone();
@@ -265,7 +265,7 @@ mod test {
         let mut hasher = DefaultHasher::new();
         c1.hash(&mut hasher);
         let result = format!("{:x}", hasher.finish());
-        assert_eq!(&result, "b1b43e91f6d6109f");
+        assert_eq!(&result, "699d38210741194e");
 
         // Test 'Ord' and 'PartialOrd' implementations
         let mut values = (value - 100..value).collect::<Vec<_>>();

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -599,7 +599,7 @@ mod test {
         // Test 'Debug' implementation
         assert_eq!(
             format!("{:?}", c1),
-            "HomomorphicCommitment(f09a7f46c5e3cbadc4c1e84c10278cffab2cb902f7b6f37223c88dd548877a6a)"
+            "HomomorphicCommitment(601cdc5c97e94bb16ae56f75430f8ab3ef4703c7d89ca9592e8acadc81629f0e)"
         );
         // Test 'Clone' implementation
         let c2 = c1.clone();
@@ -609,7 +609,7 @@ mod test {
         let mut hasher = DefaultHasher::new();
         c1.hash(&mut hasher);
         let result = format!("{:x}", hasher.finish());
-        assert_eq!(&result, "b1b43e91f6d6109f");
+        assert_eq!(&result, "699d38210741194e");
 
         // Test 'Ord' and 'PartialOrd' implementations
         let mut values = (value - 100..value).collect::<Vec<_>>();
@@ -660,50 +660,50 @@ mod test {
                 ExtensionDegree::DefaultPedersen => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(f09a7f46c5e3cbadc4c1e84c10278cffab2cb902f7b6f37223c88dd548877a6a)"
+                        "HomomorphicCommitment(601cdc5c97e94bb16ae56f75430f8ab3ef4703c7d89ca9592e8acadc81629f0e)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "b1b43e91f6d6109f");
+                    assert_eq!(&result, "699d38210741194e");
                 },
                 ExtensionDegree::AddOneBasePoint => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(2486eca30cadb896bc192e53de7d26361b44ddf892ee3e67a6b232483a8e167e)"
+                        "HomomorphicCommitment(f0019440ae20b39ba55a88f27ebd7ca56857251beca1047a3b195dc93642d829)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "85b6de79a0c73eef");
+                    assert_eq!(&result, "fb68d75431b3a0b0");
                 },
                 ExtensionDegree::AddTwoBasePoints => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(9c46efbf4652570045bcd519631aba3e13265a5f75e2b90473b2f556b4a5cc4c)"
+                        "HomomorphicCommitment(b09789e597115f592491009f18ef4ec13ba7018a77e9df1729f1e2611b237a06)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "5784c866707a1107");
+                    assert_eq!(&result, "61dd716dc29a5fc5");
                 },
                 ExtensionDegree::AddThreeBasePoints => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(4cb95250992c6c71260957403e331d6a7d1f3dd82500699007a2c32b4dff7a23)"
+                        "HomomorphicCommitment(f8356cbea349191683f84818ab5203e48b04fef42f812ddf7d9b92df966c8473)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "7b2c5512ec8a20ee");
+                    assert_eq!(&result, "49e988f621628ebc");
                 },
                 ExtensionDegree::AddFourBasePoints => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(9c877782e158d5fc982ef4cb88a3d3d7eec58f86e55f2e662eacbf6faa6fe21e)"
+                        "HomomorphicCommitment(1e113af7e33ac15b328e298239f3796e5061a0863d1a69e297ee8d81ee6e1f22)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "bde140256c260df0");
+                    assert_eq!(&result, "aff1b9967c7bffe7");
                 },
                 ExtensionDegree::AddFiveBasePoints => {
                     assert_eq!(
                         format!("{:?}", c1),
-                        "HomomorphicCommitment(86384602b8f880c75df5ce0629d5c472ec7d882c00d7de7c5d68463a7a6ec35b)"
+                        "HomomorphicCommitment(126844ee6889dd065ccc0c47e16ea23697f72e6ecce70f5e3fef320d843c332e)"
                     );
                     let result = format!("{:x}", hasher.finish());
-                    assert_eq!(&result, "88db07fcdaf311d8");
+                    assert_eq!(&result, "e27df20b2dd195ee");
                 },
             }
 

--- a/src/ristretto/ristretto_com_sig.rs
+++ b/src/ristretto/ristretto_com_sig.rs
@@ -92,11 +92,11 @@ use crate::{
 /// use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
 ///
 /// let commitment =
-///     HomomorphicCommitment::from_hex("d6cca5cc4cc302c1854a118221d6cf64d100b7da76665dae5199368f3703c665").unwrap();
+///     HomomorphicCommitment::from_hex("167c6df11bf8106e89328c297e57423dc2a9be53df1ee63f6e50b4610104ab4a").unwrap();
 /// let r_nonce =
-///     HomomorphicCommitment::from_hex("9607f72d84d704825864a4455c2325509ecc290eb9419bbce7ff05f1f578284c").unwrap();
-/// let u = RistrettoSecretKey::from_hex("0fd60e6479507fec35a46d2ec9da0ae300e9202e613e99b8f2b01d7ef6eccc02").unwrap();
-/// let v = RistrettoSecretKey::from_hex("9ae6621dd99ecc252b90a0eb69577c6f3d2e1e8abcdd43bfd0297afadf95fb0b").unwrap();
+///     HomomorphicCommitment::from_hex("4033e00996e61df2ea1abd1494b751b946663e21a20e2729c6592712beb15356").unwrap();
+/// let u = RistrettoSecretKey::from_hex("f44bbc3374b172f77ffa8b904ddf0ad9f879b3e6183f9e440c57e7f01e851300").unwrap();
+/// let v = RistrettoSecretKey::from_hex("fd54afb2d8008c8a3af10272b24161247b2b7ae11687813fe9fb03e34dd7f009").unwrap();
 /// let sig = RistrettoComSig::new(r_nonce, u, v);
 /// let e = Blake256::digest(b"Maskerade");
 /// let factory = PedersenCommitmentFactory::default();


### PR DESCRIPTION
Breaking change - any project based on a specific commitment in `tari_crypto` needs to be updated, as a commitment for the same value and blinding factor will now yield a different commitment. This was a necessary change as as described below.

- Changed NUMS constants used for the generators to make use of domain separated labels and not use iterative hashing of the Ristretto base point.
- Version update to `0.13.4` (this will align the version and tag as the previous version is `0.13.2` and the previous tag is `0.13.3`)