### PR TITLE
feat: Guarded trait for secrets protection guarantee

### DIFF
--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,0 +1,50 @@
+use std::ops::Deref;
+use std::fmt;
+use zeroize::Zeroize;
+
+/// A "transparent" wrapper that doesn't allow to print value.
+///
+/// It doesn't implement `Deref` to avoid any
+/// accidental usage of a protected value.
+pub struct GuardedSecret<T: Guarded> {
+    inner: T::Secret,
+}
+
+impl<T: Guarded> Drop for GuardedSecret<T> {
+    /// Clear the secret key value in memory when it goes out of scope
+    fn drop(&mut self) {
+        self.inner.zeroize()
+    }
+}
+
+impl<T: Guarded> GuardedSecret<T> {
+    pub fn reveal(&self) -> RevealedSecret<'_, T> {
+        RevealedSecret {
+            secret: &self.inner,
+        }
+    }
+}
+
+impl<T: Guarded> fmt::Debug for GuardedSecret<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "***")
+    }
+}
+
+pub struct RevealedSecret<'a, T: Guarded> {
+    secret: &'a T::Secret,
+}
+
+pub trait Guarded
+where
+    Self: Sized,
+    Self: Deref<Target = GuardedSecret<Self>>
+{
+    type Secret: Zeroize;
+}
+
+impl<'a, T: Guarded> fmt::Debug for RevealedSecret<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,114 +1,44 @@
-use std::ops::Deref;
-use std::cmp::Ordering;
-use std::fmt;
+use std::{fmt, ops::Deref};
 use zeroize::Zeroize;
+
+pub trait Guarded
+where
+    Self: Sized,
+    Self: Deref<Target = GuardedSecret<Self::Secret>>,
+{
+    type Secret: Zeroize;
+}
 
 /// A "transparent" wrapper that doesn't allow to print value.
 ///
 /// It doesn't implement `Deref` to avoid any
 /// accidental usage of a protected value.
-pub struct GuardedSecret<T: Guarded> {
-    inner: T::Secret,
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Default)]
+pub struct GuardedSecret<T: Zeroize> {
+    secret: T,
 }
 
-impl<T: Guarded> Default for GuardedSecret<T>
-where
-    T::Secret: Default,
-{
-    fn default() -> Self {
-        Self {
-            inner: T::Secret::default(),
-        }
+impl<T: Zeroize> GuardedSecret<T> {
+    pub fn new(secret: T) -> Self {
+        Self { secret }
     }
 }
 
-impl<T: Guarded> Clone for GuardedSecret<T>
-where
-    T::Secret: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl<T: Guarded> PartialEq for GuardedSecret<T>
-where
-    T::Secret: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
-    }
-}
-
-impl<T: Guarded> Eq for GuardedSecret<T>
-where
-    T::Secret: Eq,
-{}
-
-impl<T: Guarded> PartialOrd for GuardedSecret<T>
-where
-    T::Secret: PartialOrd,
-{
-    fn partial_cmp(&self, other: &Self) -> Ordering {
-        self.inner.partial_cmp(&other.inner)
-    }
-}
-
-impl<T: Guarded> Ord for GuardedSecret<T>
-where
-    T::Secret: Ord,
-{
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.inner.cmp(&other.inner)
-    }
-}
-
-
-impl<T: Guarded> Drop for GuardedSecret<T> {
+impl<T: Zeroize> Drop for GuardedSecret<T> {
     /// Clear the secret key value in memory when it goes out of scope
     fn drop(&mut self) {
-        self.inner.zeroize()
+        self.secret.zeroize()
     }
 }
 
-impl<T: Guarded> GuardedSecret<T> {
-    pub fn reveal(&self) -> RevealedSecret<'_, T> {
-        RevealedSecret {
-            secret: &self.inner,
-        }
-    }
-}
-
-impl<T: Guarded> fmt::Debug for GuardedSecret<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "***")
-    }
-}
-
-pub trait Guarded
-where
-    Self: Sized,
-    Self: Deref<Target = GuardedSecret<Self>>
-{
-    type Secret: Zeroize;
-}
-
-pub struct RevealedSecret<'a, T: Guarded> {
-    secret: &'a T::Secret,
-}
-
-impl<T: Guarded> Deref for RevealedSecret<'_, T> {
-    type Target = T::Secret;
-
-    fn deref(&self) -> &Self::Target {
+impl<T: Zeroize> GuardedSecret<T> {
+    pub fn reveal(&self) -> &T {
         &self.secret
     }
 }
 
-impl<'a, T: Guarded> fmt::Debug for RevealedSecret<'a, T> {
+impl<T: Zeroize> fmt::Debug for GuardedSecret<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+        write!(f, "***")
     }
 }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,4 +1,5 @@
 use std::{fmt, ops::Deref};
+
 use zeroize::Zeroize;
 
 pub trait Guarded

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,4 +1,5 @@
 use std::ops::Deref;
+use std::cmp::Ordering;
 use std::fmt;
 use zeroize::Zeroize;
 
@@ -9,6 +10,61 @@ use zeroize::Zeroize;
 pub struct GuardedSecret<T: Guarded> {
     inner: T::Secret,
 }
+
+impl<T: Guarded> Default for GuardedSecret<T>
+where
+    T::Secret: Default,
+{
+    fn default() -> Self {
+        Self {
+            inner: T::Secret::default(),
+        }
+    }
+}
+
+impl<T: Guarded> Clone for GuardedSecret<T>
+where
+    T::Secret: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T: Guarded> PartialEq for GuardedSecret<T>
+where
+    T::Secret: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<T: Guarded> Eq for GuardedSecret<T>
+where
+    T::Secret: Eq,
+{}
+
+impl<T: Guarded> PartialOrd for GuardedSecret<T>
+where
+    T::Secret: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Ordering {
+        self.inner.partial_cmp(&other.inner)
+    }
+}
+
+impl<T: Guarded> Ord for GuardedSecret<T>
+where
+    T::Secret: Ord,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner.cmp(&other.inner)
+    }
+}
+
 
 impl<T: Guarded> Drop for GuardedSecret<T> {
     /// Clear the secret key value in memory when it goes out of scope
@@ -31,16 +87,24 @@ impl<T: Guarded> fmt::Debug for GuardedSecret<T> {
     }
 }
 
-pub struct RevealedSecret<'a, T: Guarded> {
-    secret: &'a T::Secret,
-}
-
 pub trait Guarded
 where
     Self: Sized,
     Self: Deref<Target = GuardedSecret<Self>>
 {
     type Secret: Zeroize;
+}
+
+pub struct RevealedSecret<'a, T: Guarded> {
+    secret: &'a T::Secret,
+}
+
+impl<T: Guarded> Deref for RevealedSecret<'_, T> {
+    type Target = T::Secret;
+
+    fn deref(&self) -> &Self::Target {
+        &self.secret
+    }
 }
 
 impl<'a, T: Guarded> fmt::Debug for RevealedSecret<'a, T> {

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -394,7 +394,7 @@ pub trait DerivedKeyDomain: DomainSeparation {
         D: Digest,
         S: AsRef<str>,
     {
-        if primary_key.as_ref().len() < D::output_size() {
+        if primary_key.len() < D::output_size() {
             return Err(HashingError::InputTooShort);
         }
         let hash = DomainSeparatedHasher::<D, Self>::new(label)

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -12,6 +12,8 @@ use rand::{CryptoRng, Rng};
 use serde::{de::DeserializeOwned, ser::Serialize};
 use tari_utilities::ByteArray;
 
+use crate::guard::Guarded;
+
 /// A trait specifying common behaviour for representing `SecretKey`s. Specific elliptic curve
 /// implementations need to implement this trait for them to be used in Tari.
 ///
@@ -26,7 +28,7 @@ use tari_utilities::ByteArray;
 /// let k = RistrettoSecretKey::random(&mut rng);
 /// let p = RistrettoPublicKey::from_secret_key(&k);
 /// ```
-pub trait SecretKey: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default {
+pub trait SecretKey: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default + Guarded {
     /// The length of the key, in bytes
     fn key_length() -> usize;
     /// Generates a random secret key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate lazy_static;
 #[macro_use]
 mod macros;
 pub mod commitment;
+pub mod guard;
 pub mod hash;
 pub mod hashing;
 pub mod keys;

--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -46,7 +46,7 @@ impl HomomorphicCommitmentFactory for PedersenCommitmentFactory {
     type P = RistrettoPublicKey;
 
     fn commit(&self, k: &RistrettoSecretKey, v: &RistrettoSecretKey) -> PedersenCommitment {
-        let c = RistrettoPoint::multiscalar_mul(&[v.0, k.0], &[self.H, self.G]);
+        let c = RistrettoPoint::multiscalar_mul(&[v.reveal().clone(), k.reveal().clone()], &[self.H, self.G]);
         HomomorphicCommitment(RistrettoPublicKey::new_from_pk(c))
     }
 
@@ -121,7 +121,7 @@ mod test {
             let v = RistrettoSecretKey::random(&mut rng);
             let k = RistrettoSecretKey::random(&mut rng);
             let c = factory.commit(&k, &v);
-            let c_calc: RistrettoPoint = v.0 * H + k.0 * RISTRETTO_PEDERSEN_G;
+            let c_calc: RistrettoPoint = v.reveal() * H + k.reveal() * RISTRETTO_PEDERSEN_G;
             assert_eq!(RistrettoPoint::from(c.as_public_key()), c_calc);
             assert!(factory.open(&k, &v, &c));
             // A different value doesn't open the commitment

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -296,7 +296,7 @@ mod test {
                 let c_extended = factory.commit_extended(&k_vec, &v).unwrap();
                 let mut c_calc: RistrettoPoint = v.0 * H + k_vec[0].0 * RISTRETTO_PEDERSEN_G;
                 for i in 1..(extension_degree as usize) {
-                    c_calc += k_vec[i].0 * RISTRETTO_NUMS_POINTS[i];
+                    c_calc += k_vec[i].reveal().0 * RISTRETTO_NUMS_POINTS[i];
                 }
                 assert_eq!(RistrettoPoint::from(c_extended.as_public_key()), c_calc);
 

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -7,7 +7,7 @@ use std::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
-    ops::{Add, Mul, Sub},
+    ops::{Add, Mul, Sub, Deref},
 };
 
 use blake2::Blake2b;
@@ -24,10 +24,24 @@ use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, Hashable};
 use zeroize::Zeroize;
 
 use crate::{
+    guard::{Guarded, GuardedSecret},
     errors::HashingError,
     hashing::{DerivedKeyDomain, DomainSeparatedHasher, DomainSeparation},
     keys::{DiffieHellmanSharedSecret, PublicKey, SecretKey},
 };
+
+pub struct RistrettoSecretKey2(GuardedSecret<Self>);
+
+impl Deref for RistrettoSecretKey2 {
+    type Target = GuardedSecret<Self>;
+    fn deref(&self) -> &GuardedSecret<Self> {
+        &self.0
+    }
+}
+
+impl Guarded for RistrettoSecretKey2 {
+    type Secret = Scalar;
+}
 
 /// The [SecretKey](trait.SecretKey.html) implementation for [Ristretto](https://ristretto.group) is a thin wrapper
 /// around the Dalek [Scalar](struct.Scalar.html) type, representing a 256-bit integer (mod the group order).

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -82,7 +82,7 @@ impl SecretKey for RistrettoSecretKey {
     /// Return a random secret key on the `ristretto255` curve using the supplied CSPRNG.
     fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         let k = Scalar::random(rng);
-        RistrettoSecretKey(GuardedSecret::new(k))
+        RistrettoSecretKey::new(k)
     }
 }
 
@@ -101,7 +101,7 @@ impl ByteArray for RistrettoSecretKey {
         let mut a = [0u8; 32];
         a.copy_from_slice(bytes);
         let k = Scalar::from_bytes_mod_order(a);
-        Ok(RistrettoSecretKey(GuardedSecret::new(k)))
+        Ok(RistrettoSecretKey::new(k))
     }
 
     /// Return the byte array for the secret key in little-endian order
@@ -133,7 +133,7 @@ impl<'a, 'b> Add<&'b RistrettoSecretKey> for &'a RistrettoSecretKey {
 
     fn add(self, rhs: &'b RistrettoSecretKey) -> RistrettoSecretKey {
         let k = self.reveal() + rhs.reveal();
-        RistrettoSecretKey(GuardedSecret::new(k))
+        RistrettoSecretKey::new(k)
     }
 }
 
@@ -142,7 +142,7 @@ impl<'a, 'b> Sub<&'b RistrettoSecretKey> for &'a RistrettoSecretKey {
 
     fn sub(self, rhs: &'b RistrettoSecretKey) -> RistrettoSecretKey {
         let k = self.reveal() - rhs.reveal();
-        RistrettoSecretKey(GuardedSecret::new(k))
+        RistrettoSecretKey::new(k)
     }
 }
 
@@ -167,13 +167,13 @@ define_mul_variants!(
 impl From<u64> for RistrettoSecretKey {
     fn from(v: u64) -> Self {
         let s = Scalar::from(v);
-        RistrettoSecretKey(GuardedSecret::new(s))
+        RistrettoSecretKey::new(s)
     }
 }
 
 impl From<Scalar> for RistrettoSecretKey {
     fn from(s: Scalar) -> Self {
-        RistrettoSecretKey(GuardedSecret::new(s))
+        RistrettoSecretKey::new(s)
     }
 }
 
@@ -439,7 +439,7 @@ impl<'a, 'b> Mul<&'b RistrettoSecretKey> for &'a RistrettoSecretKey {
 
     fn mul(self, rhs: &'b RistrettoSecretKey) -> RistrettoSecretKey {
         let p = rhs.reveal() * self.reveal();
-        RistrettoSecretKey(GuardedSecret::new(p))
+        RistrettoSecretKey::new(p)
     }
 }
 

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -50,7 +50,7 @@ use crate::{
 /// let _k3 = RistrettoSecretKey::random(&mut rng);
 /// ```
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
-pub struct RistrettoSecretKey(pub(crate) GuardedSecret<Scalar>);
+pub struct RistrettoSecretKey(GuardedSecret<Scalar>);
 
 const SCALAR_LENGTH: usize = 32;
 const PUBLIC_KEY_LENGTH: usize = 32;

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -50,7 +50,7 @@ use crate::{
 /// let _k3 = RistrettoSecretKey::random(&mut rng);
 /// ```
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
-pub struct RistrettoSecretKey(GuardedSecret<Scalar>);
+pub struct RistrettoSecretKey(pub(crate) GuardedSecret<Scalar>);
 
 const SCALAR_LENGTH: usize = 32;
 const PUBLIC_KEY_LENGTH: usize = 32;
@@ -466,12 +466,6 @@ define_mul_variants!(
 
 //----------------------------------         PublicKey From implementations      -------------------------------------//
 
-impl From<RistrettoSecretKey> for Scalar {
-    fn from(k: RistrettoSecretKey) -> Self {
-        k.reveal().clone()
-    }
-}
-
 impl From<RistrettoPublicKey> for RistrettoPoint {
     fn from(pk: RistrettoPublicKey) -> Self {
         pk.point
@@ -803,9 +797,10 @@ mod test {
     fn visibility_test() {
         let key =
             RistrettoSecretKey::from_hex("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c").unwrap();
+        // Checking for both: bytes or hex representation
         let invisible = format!("{:?}", key);
-        assert!(!invisible.contains("016c"));
+        assert!(!invisible.contains("016c") && !invisible.contains("198"));
         let visible = format!("{:?}", key.reveal());
-        assert!(visible.contains("016c"));
+        assert!(visible.contains("016c") || visible.contains("198"));
     }
 }

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -64,10 +64,21 @@ impl Guarded for RistrettoSecretKey2 {
 /// let _k3 = RistrettoSecretKey::random(&mut rng);
 /// ```
 #[derive(Eq, Clone, Default)]
-pub struct RistrettoSecretKey(pub(crate) Scalar);
+pub struct RistrettoSecretKey(GuardedSecret<Self>);
 
 const SCALAR_LENGTH: usize = 32;
 const PUBLIC_KEY_LENGTH: usize = 32;
+
+impl Guarded for RistrettoSecretKey {
+    type Secret = Scalar;
+}
+
+impl Deref for RistrettoSecretKey {
+    type Target = GuardedSecret<Self>;
+    fn deref(&self) -> &GuardedSecret<Self> {
+        &self.0
+    }
+}
 
 //-----------------------------------------   Ristretto Secret Key    ------------------------------------------------//
 impl SecretKey for RistrettoSecretKey {
@@ -728,7 +739,7 @@ mod test {
         let ptr;
         {
             let k = RistrettoSecretKey::random(&mut rng);
-            ptr = (k.0).as_bytes().as_ptr();
+            ptr = (k.0).reveal().as_bytes().as_ptr();
         }
         // In release mode, the memory can already be reclaimed by this stage due to optimisations, and so this test
         // can fail in release mode, even though the values were effectively scrubbed.


### PR DESCRIPTION
An attempt to find a good solution for https://github.com/tari-project/tari-crypto/pull/112#issuecomment-1176732135 they led me to this implementation (an alternative to https://github.com/tari-project/tari-crypto/pull/112) and curious conclusions.

Description:
This PR introduces a special `Guarded` trait that forces an implementation to:
- always wrap a (secret) value to the `GuardedWrapper` (that implements `Debug`, but never prints the secret value)
- implement `Zeroize` for the secret (and it always be called by the `GuardedWrapper`)

The `GuardedWrapper` has a special method `.reveal()` that returns a reference to a secret.
The beniefit of that approach: we have `.reveal()` calls everywhere we get access to a secret value and we could `grep` sources to see all the places the secret is revealed. Like `.unwrap()` approach, but for secrets. It's always clear now in reviewing PRs where we get the secret value

Another change is removing `From<RistrettoSecretKey> for Scalar` implementation, because `Scalar` implements `Copy` and easily copied in that method, but the copied value will never be `zeroized`. The original secret key is zeroized, becuase `Drop` will be called after the `From` implementation:

```rust
impl From<RistrettoSecretKey> for Scalar {
    fn from(k: RistrettoSecretKey) -> Self {
        k.0 // copied scalar `leaked` here and will never be cleared (zeroized)
        // `drop(k)` is happened here that will call `k.zeroize()` 
   }
}
```

The drawback of that approach: we have to `Clone` values instead of `Copy`, because we couldn't have both `Copy` and `Drop` at the same time.
The extra costs for cloning could be eliminated by some refactoring to using references to secrets instead of owning them.