### PR TITLE
fix(hashing): avoid heap allocations for domain-separated hashing API

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
+          toolchain: nightly-2022-01-17
           args: --all -- --check
       - name: Install cargo-lints
         uses: actions-rs/cargo@v1

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -76,9 +76,9 @@ pub trait DomainSeparation {
     }
 }
 
-/// Converts a byte value to ASCII bytes that represent its value. This function returns a tuple containing the
-/// inclusive index of the most significant decimal value byte. For example,
-/// byte_to_decimal_ascii_bytes(0) returns (2, [0, 0, 48]).
+/// Converts a byte value to ASCII bytes that represent its value in big-endian order. This function returns a tuple
+/// containing the inclusive index of the most significant decimal value byte, and the 3 ASCII bytes (big-endian). For
+/// example, byte_to_decimal_ascii_bytes(0) returns (2, [0, 0, 48]).
 /// byte_to_decimal_ascii_bytes(42) returns (1, [0, 52, 50]).
 /// byte_to_decimal_ascii_bytes(255) returns (0, [50, 53, 53]).
 fn byte_to_decimal_ascii_bytes(mut byte: u8) -> (usize, [u8; 3]) {
@@ -187,11 +187,11 @@ impl<D: Digest> AsRef<[u8]> for DomainSeparatedHash<D> {
 /// Calculating a signature challenge
 ///
 /// ```
-/// # use tari_crypto::{
-/// #    hash::blake2::Blake256,
-/// #    hashing::{DomainSeparatedHash, DomainSeparatedHasher, GenericHashDomain, DomainSeparation},
-/// # };
 /// # use tari_utilities::hex::{to_hex, Hex};
+/// use tari_crypto::{
+///     hash::blake2::Blake256,
+///     hashing::{DomainSeparatedHash, DomainSeparatedHasher, DomainSeparation, GenericHashDomain},
+/// };
 ///
 /// struct Card {
 ///     name: &'static str,

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -55,7 +55,7 @@ pub trait DomainSeparation {
     /// typically hard-coded into the implementing type, and the label is provided per specific application of the
     /// domain
     fn domain_separation_tag<S: AsRef<str>>(label: S) -> String {
-        format!("{}.v{}.{}", Self::domain(), char::from(Self::version()), label.as_ref())
+        format!("{}.v{}.{}", Self::domain(), Self::version(), label.as_ref())
     }
 
     /// Adds the domain separation tag to the given digest. The domain separation tag is defined as
@@ -63,17 +63,39 @@ pub trait DomainSeparation {
     /// type, and the label is provided per specific application of the domain.
     fn add_domain_separation_tag<S: AsRef<[u8]>, D: Digest>(digest: &mut D, label: S) {
         let domain = Self::domain();
-        let version = &[Self::version()];
+        let (version_offset, version) = byte_to_decimal_ascii_bytes(Self::version());
         // 3 additional bytes are 2 x '.' delimiters and 'v' tag for version
-        let len = domain.len() + version.len() + label.as_ref().len() + 3;
+        let len = domain.len() + (3 - version_offset) + label.as_ref().len() + 3;
         let len = (len as u64).to_le_bytes();
         digest.update(len);
         digest.update(domain);
         digest.update(b".v");
-        digest.update(version);
+        digest.update(&version[version_offset..]);
         digest.update(b".");
         digest.update(label.as_ref());
     }
+}
+
+/// Converts a byte value to ASCII bytes that represent its value. This function returns a tuple containing the
+/// inclusive index of the most significant decimal value byte. For example,
+/// byte_to_decimal_ascii_bytes(0) returns (2, [0, 0, 48]).
+/// byte_to_decimal_ascii_bytes(42) returns (1, [0, 52, 50]).
+/// byte_to_decimal_ascii_bytes(255) returns (0, [50, 53, 53]).
+fn byte_to_decimal_ascii_bytes(mut byte: u8) -> (usize, [u8; 3]) {
+    const ZERO_ASCII_CHAR: u8 = 48;
+    // A u8 can only ever be a 3 char number.
+    let mut bytes = [0u8, 0u8, ZERO_ASCII_CHAR];
+    let mut pos = 3usize;
+    if byte == 0 {
+        return (2, bytes);
+    }
+    while byte > 0 {
+        let rem = byte % 10;
+        byte /= 10;
+        bytes[pos - 1] = ZERO_ASCII_CHAR + rem;
+        pos -= 1;
+    }
+    (pos, bytes)
 }
 
 //--------------------------------------     Domain Separated Hash   ---------------------------------------------------
@@ -149,7 +171,7 @@ impl<D: Digest> AsRef<[u8]> for DomainSeparatedHash<D> {
 ///         .finalize()
 /// }
 ///
-/// assert_eq!(GenericHashDomain::domain_separation_tag("card_id"), "com.tari.generic.v\u{1}.card_id");
+/// assert_eq!(GenericHashDomain::domain_separation_tag("card_id"), "com.tari.generic.v1.card_id");
 /// let card = Card {
 ///     name: "Rincewind",
 ///     strength: 8,
@@ -158,7 +180,7 @@ impl<D: Digest> AsRef<[u8]> for DomainSeparatedHash<D> {
 /// let id = card_id(&card);
 /// assert_eq!(
 ///     to_hex(id.as_ref()),
-///     "67c370c3b36c25910d5b1ba93e714fe532b5bd206a40d05d9c99689479d2ab34"
+///     "44fb39bfdd20c93ddf542e4b2d1f4b06448aa1fa2b9c4d138d8e7bbb19aa7c65"
 /// );
 /// ```
 ///
@@ -184,12 +206,12 @@ impl<D: Digest> AsRef<[u8]> for DomainSeparatedHash<D> {
 ///
 /// assert_eq!(
 ///     GenericHashDomain::domain_separation_tag("schnorr_challenge"),
-///     "com.tari.generic.v\u{1}.schnorr_challenge"
+///     "com.tari.generic.v1.schnorr_challenge"
 /// );
 /// let challenge = calculate_challenge("All is well.");
 /// assert_eq!(
 ///     to_hex(challenge.as_ref()),
-///     "30536962e720948abc5f24c71f64779897cff40797f04ec113cfad3c8a9a380c"
+///     "6cd8efe7d7f1673ed8cfc0ac67d6979eb50afdbf276adf5221caabfbfd01da8c"
 /// );
 /// ```
 #[derive(Debug, Clone, Default)]
@@ -290,22 +312,19 @@ impl DomainSeparation for MacDomain {
 /// ```
 ///
 /// ```
-/// # use sha3::Sha3_256;
-/// # use tari_crypto::hashing::{Mac, MacDomain, DomainSeparation};
-/// # use tari_utilities::hex::to_hex;
+/// use sha3::Sha3_256;
+/// use tari_crypto::hashing::{DomainSeparation, Mac, MacDomain};
+/// use tari_utilities::hex::to_hex;
 ///
 /// fn generate_api_hmac(key: &[u8], msg: &[u8]) -> Mac<Sha3_256> {
 ///     Mac::<Sha3_256>::generate(key, msg, "api.auth")
 /// }
 ///
-/// assert_eq!(
-///     MacDomain::domain_separation_tag("api.auth"),
-///     "com.tari.mac.v\u{1}.api.auth"
-/// );
+/// assert_eq!(MacDomain::domain_separation_tag("api.auth"), "com.tari.mac.v1.api.auth");
 /// let mac = generate_api_hmac(b"a secret shared key", b"a message");
 /// assert_eq!(
 ///     to_hex(mac.as_ref()),
-///     "2a58eb569f77d6f71092a2a0cfaf0a91218b38200f41b2b960209d7703c0d624"
+///     "796eb496b6672b1b7c4021e603d6b833121d35cd282a1555e3f9dd2eda5658b8"
 /// );
 /// ```
 pub struct Mac<D: Digest> {
@@ -375,12 +394,12 @@ impl<D: Digest> Deref for Mac<D> {
 /// let key_1 = wallet_keys(&key, 1).unwrap();
 /// assert_eq!(
 ///     key_1.to_hex(),
-///     "cd4e2be57c53f9b26eb1e9ca13d93b18f3b791d7fba5c66daaf8fa630d24ed0c"
+///     "b778b8b5041fbde6c78be5bafd6d62633824bf303c97736d7337b3f6f70c4e0b"
 /// );
 /// let key_64 = wallet_keys(&key, 64).unwrap();
 /// assert_eq!(
 ///     key_64.to_hex(),
-///     "0e56e468fd2d7f02995316489dd3efb63445db81b00959ee98510484eeff2a0a"
+///     "09e5204c93406ef3334ff5f7a4d5d84199ceb9119fafcb98928fa95e95f0ae05"
 /// );
 /// ```
 pub trait DerivedKeyDomain: DomainSeparation {
@@ -416,7 +435,14 @@ mod test {
 
     use crate::{
         hash::blake2::Blake256,
-        hashing::{DomainSeparatedHasher, DomainSeparation, GenericHashDomain, Mac, MacDomain},
+        hashing::{
+            byte_to_decimal_ascii_bytes,
+            DomainSeparatedHasher,
+            DomainSeparation,
+            GenericHashDomain,
+            Mac,
+            MacDomain,
+        },
     };
 
     #[test]
@@ -424,7 +450,7 @@ mod test {
     fn mac_domain_metadata() {
         assert_eq!(MacDomain::version(), 1);
         assert_eq!(MacDomain::domain(), "com.tari.mac");
-        assert_eq!(MacDomain::domain_separation_tag("test"), "com.tari.mac.v\u{1}.test");
+        assert_eq!(MacDomain::domain_separation_tag("test"), "com.tari.mac.v1.test");
     }
 
     #[test]
@@ -438,7 +464,7 @@ mod test {
         assert_eq!(hash.as_ref(), hash2.as_ref());
         assert_eq!(
             to_hex(hash.as_ref()),
-            "0b987ccab67a7af149753e284e6eb0865cfba71f7c224f201a9dcc9dc97de8d8"
+            "a8326620e305430a0b632a0a5e33c6c1124d7513b4bd84736faaa3a0b9ba557f"
         );
     }
 
@@ -451,7 +477,7 @@ mod test {
             .finalize();
         let expected = Blake256::new()
             .chain(26u64.to_le_bytes())
-            .chain("com.tari.generic.v\u{1}.mytest")
+            .chain("com.tari.generic.v1.mytest".as_bytes())
             .chain(9u64.to_le_bytes())
             .chain("rincewind".as_bytes())
             .chain(3u64.to_le_bytes())
@@ -473,7 +499,7 @@ mod test {
                 "com.discworld"
             }
         }
-        let domain = format!("com.discworld.v{}.turtles", char::from(42));
+        let domain = "com.discworld.v42.turtles";
         assert_eq!(MyDemoHasher::domain_separation_tag("turtles"), domain);
         let hash = DomainSeparatedHasher::<Blake2b, MyDemoHasher>::new("turtles").finalize();
         let expected = Blake2b::default()
@@ -512,7 +538,7 @@ mod test {
         let hash = DomainSeparatedHasher::<Blake2b, MyDemoHasher>::new("turtles")
             .chain("elephants")
             .finalize();
-        assert_eq!(to_hex(hash.as_ref()), "a222586e3e8295a14e32db059a30e390872dc8bd649e14e91bf90a5e3574efe5510b548863f15c0ad7d4d9ce182ac88f0ef58dd0103a42e76275a0beaac1a4b3");
+        assert_eq!(to_hex(hash.as_ref()), "64a89c7160a1076a725fac97d3f67803abd0991d82518a595072fa62df4c870bddee9160f591231c381087831bf6925616013de317ce0b02846585caf41942ac");
     }
 
     #[test]
@@ -523,10 +549,17 @@ mod test {
         //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `LengthExtensionAttackResistant` is not implemented for
         //          `Sha256`
         let mac = Mac::<Blake256>::generate(&key, "test message", "test");
-        assert_eq!(MacDomain::domain_separation_tag("test"), "com.tari.mac.v\u{1}.test");
+        assert_eq!(MacDomain::domain_separation_tag("test"), "com.tari.mac.v1.test");
         assert_eq!(
             to_hex(mac.as_ref()),
-            "78404d93596f5c0b0fdc2775ae0e223b380d7469cb63a5b8af1fd5325ff653de"
+            "9bcfbe2bad73b14ac42f673ddca34e82ce03cbbac69d34526004f5d108dff061"
         )
+    }
+
+    #[test]
+    fn check_bytes_to_decimal_ascii_bytes() {
+        assert_eq!(byte_to_decimal_ascii_bytes(0), (2, [0u8, 0, 48]));
+        assert_eq!(byte_to_decimal_ascii_bytes(42), (1, [0u8, 52, 50]));
+        assert_eq!(byte_to_decimal_ascii_bytes(255), (0, [50u8, 53, 53]));
     }
 }

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -82,7 +82,9 @@ impl ByteArray for RistrettoSecretKey {
     /// not exactly 32 bytes long, `from_bytes` returns an error. This function is guaranteed to return a valid key
     /// in the group since it performs a mod _l_ on the input.
     fn from_bytes(bytes: &[u8]) -> Result<RistrettoSecretKey, ByteArrayError>
-    where Self: Sized {
+    where
+        Self: Sized,
+    {
         if bytes.len() != 32 {
             return Err(ByteArrayError::IncorrectLength);
         }
@@ -377,7 +379,9 @@ impl ByteArray for RistrettoPublicKey {
     /// * The byte array is not exactly 32 bytes
     /// * The byte array does not represent a valid (compressed) point on the ristretto255 curve
     fn from_bytes(bytes: &[u8]) -> Result<RistrettoPublicKey, ByteArrayError>
-    where Self: Sized {
+    where
+        Self: Sized,
+    {
         // Check the length here, because The Ristretto constructor panics rather than returning an error
         if bytes.len() != 32 {
             return Err(ByteArrayError::IncorrectLength);
@@ -765,7 +769,7 @@ mod test {
         assert_eq!(RistrettoKdf::domain(), "com.tari.kdf.ristretto");
         assert_eq!(
             RistrettoKdf::domain_separation_tag("test"),
-            "com.tari.kdf.ristretto.v1.test"
+            "com.tari.kdf.ristretto.v\u{1}.test"
         );
     }
 
@@ -783,11 +787,11 @@ mod test {
         let derived2 = RistrettoKdf::generate::<Blake256, _>(key.as_bytes(), b"derived2", "test").unwrap();
         assert_eq!(
             derived1.to_hex(),
-            "e8df6fa40344c1fde721e9a35d46daadb48dc66f7901a9795ebb0374474ea601"
+            "2597f69a8c8bd4254f5f994192fdb69a4e507eff0e50fa10d366cf0af125ad03"
         );
         assert_eq!(
             derived2.to_hex(),
-            "3ae035e2663d9c561300cca67743ccdb56ea07ca7dacd8394356c4354b030e0c"
+            "ca5e1254c3aa119be3cd5f7a1173b7e15cf0197a1a14ce8a6146e29ed3d89f0b"
         );
     }
 }

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -765,7 +765,7 @@ mod test {
         assert_eq!(RistrettoKdf::domain(), "com.tari.kdf.ristretto");
         assert_eq!(
             RistrettoKdf::domain_separation_tag("test"),
-            "com.tari.kdf.ristretto.v\u{1}.test"
+            "com.tari.kdf.ristretto.v1.test"
         );
     }
 
@@ -783,11 +783,11 @@ mod test {
         let derived2 = RistrettoKdf::generate::<Blake256, _>(key.as_bytes(), b"derived2", "test").unwrap();
         assert_eq!(
             derived1.to_hex(),
-            "2597f69a8c8bd4254f5f994192fdb69a4e507eff0e50fa10d366cf0af125ad03"
+            "e8df6fa40344c1fde721e9a35d46daadb48dc66f7901a9795ebb0374474ea601"
         );
         assert_eq!(
             derived2.to_hex(),
-            "ca5e1254c3aa119be3cd5f7a1173b7e15cf0197a1a14ce8a6146e29ed3d89f0b"
+            "3ae035e2663d9c561300cca67743ccdb56ea07ca7dacd8394356c4354b030e0c"
         );
     }
 }

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -82,9 +82,7 @@ impl ByteArray for RistrettoSecretKey {
     /// not exactly 32 bytes long, `from_bytes` returns an error. This function is guaranteed to return a valid key
     /// in the group since it performs a mod _l_ on the input.
     fn from_bytes(bytes: &[u8]) -> Result<RistrettoSecretKey, ByteArrayError>
-    where
-        Self: Sized,
-    {
+    where Self: Sized {
         if bytes.len() != 32 {
             return Err(ByteArrayError::IncorrectLength);
         }
@@ -379,9 +377,7 @@ impl ByteArray for RistrettoPublicKey {
     /// * The byte array is not exactly 32 bytes
     /// * The byte array does not represent a valid (compressed) point on the ristretto255 curve
     fn from_bytes(bytes: &[u8]) -> Result<RistrettoPublicKey, ByteArrayError>
-    where
-        Self: Sized,
-    {
+    where Self: Sized {
         // Check the length here, because The Ristretto constructor panics rather than returning an error
         if bytes.len() != 32 {
             return Err(ByteArrayError::IncorrectLength);


### PR DESCRIPTION
Hashing is an extremely common operation and therefore should avoid using the heap. 
This PR removes the allocation of the hash, the full tag string, and the label string from the `DomainSeparatedHasher`.  

~~BREAKING CHANGE: the version byte was previously converted to a decimal string representation before being applied to the digest. In order to maintain the same hashes, an allocation would necessarily`*` be required i.e. `let v_str = Self::version().to_string()`. Instead, the version byte is used directly in the challenge.~~

~~`*` barring some fancy use of `std::fmt::Formatter`~~

Fixes #113

New commit:[b591398](https://github.com/tari-project/tari-crypto/pull/116/commits/b591398c7e634b4e025a081614e51e8d65271201) Generates the ASCII byte representation for the version number without a heap allocation.