### PR TITLE
feat: refactor PublicKey length trait to accomodate specific KEY_LEN const

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -41,8 +41,8 @@ pub trait SecretKey: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + D
 /// See [SecretKey](trait.SecretKey.html) for an example.
 pub trait PublicKey:
     ByteArray + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Serialize + DeserializeOwned
-{   
-    /// The output size len of Public Key 
+{
+    /// The output size len of Public Key
     const KEY_LEN: usize;
 
     /// The related [SecretKey](trait.SecretKey.html) type

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -44,7 +44,7 @@ pub trait PublicKey:
 {   
     /// The output size len of Public Key 
     const KEY_LEN: usize;
-    
+
     /// The related [SecretKey](trait.SecretKey.html) type
     type K: SecretKey;
 
@@ -53,7 +53,9 @@ pub trait PublicKey:
     fn from_secret_key(k: &Self::K) -> Self;
 
     /// The length of the public key when converted to bytes
-    fn key_length() -> usize;
+    fn key_length() -> usize {
+        Self::KEY_LEN
+    }
 
     /// Multiplies each of the items in `scalars` by their respective item in `points` and then adds
     /// the results to produce a single public key

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -41,7 +41,10 @@ pub trait SecretKey: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + D
 /// See [SecretKey](trait.SecretKey.html) for an example.
 pub trait PublicKey:
     ByteArray + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Serialize + DeserializeOwned
-{
+{   
+    /// The output size len of Public Key 
+    const KEY_LEN: usize;
+    
     /// The related [SecretKey](trait.SecretKey.html) type
     type K: SecretKey;
 

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -312,16 +312,14 @@ impl DomainSeparation for RistrettoGeneratorPoint {
 }
 
 impl PublicKey for RistrettoPublicKey {
+    const KEY_LEN: usize = PUBLIC_KEY_LENGTH;
+
     type K = RistrettoSecretKey;
 
     /// Generates a new Public key from the given secret key
     fn from_secret_key(k: &Self::K) -> RistrettoPublicKey {
         let pk = &k.0 * &RISTRETTO_BASEPOINT_TABLE;
         RistrettoPublicKey::new_from_pk(pk)
-    }
-
-    fn key_length() -> usize {
-        PUBLIC_KEY_LENGTH
     }
 
     fn batch_mul(scalars: &[Self::K], points: &[Self]) -> Self {

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -312,9 +312,9 @@ impl DomainSeparation for RistrettoGeneratorPoint {
 }
 
 impl PublicKey for RistrettoPublicKey {
-    const KEY_LEN: usize = PUBLIC_KEY_LENGTH;
-
     type K = RistrettoSecretKey;
+
+    const KEY_LEN: usize = PUBLIC_KEY_LENGTH;
 
     /// Generates a new Public key from the given secret key
     fn from_secret_key(k: &Self::K) -> RistrettoPublicKey {


### PR DESCRIPTION
It adds a const `KEY_LEN` to the `PublicKey` trait that specifies the associated key length.