### PR TITLE
feat: implement Digest for DomainSeparatedHasher

### DIFF
--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -258,7 +258,7 @@ impl RistrettoPublicKey {
     }
 
     /// A verifiable group generator using a domain separated hasher
-    pub fn new_generator(label: &str) -> Result<RistrettoPublicKey, HashingError> {
+    pub fn new_generator(label: &'static str) -> Result<RistrettoPublicKey, HashingError> {
         // This function requires 512 bytes of data, so let's be opinionated here and use blake2b
         let hash = DomainSeparatedHasher::<Blake2b, RistrettoGeneratorPoint>::new(label).finalize();
         if hash.as_ref().len() < 64 {
@@ -803,7 +803,7 @@ mod test {
 
     #[test]
     fn kdf_key_too_short() {
-        let err = RistrettoKdf::generate::<Blake256, _>(b"this_key_is_too_short", b"data", "test").err();
+        let err = RistrettoKdf::generate::<Blake256>(b"this_key_is_too_short", b"data", "test").err();
         assert!(matches!(err, Some(HashingError::InputTooShort)));
     }
 
@@ -811,8 +811,8 @@ mod test {
     fn kdf_test() {
         let key =
             RistrettoSecretKey::from_hex("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c").unwrap();
-        let derived1 = RistrettoKdf::generate::<Blake256, _>(key.as_bytes(), b"derived1", "test").unwrap();
-        let derived2 = RistrettoKdf::generate::<Blake256, _>(key.as_bytes(), b"derived2", "test").unwrap();
+        let derived1 = RistrettoKdf::generate::<Blake256>(key.as_bytes(), b"derived1", "test").unwrap();
+        let derived2 = RistrettoKdf::generate::<Blake256>(key.as_bytes(), b"derived2", "test").unwrap();
         assert_eq!(
             derived1.to_hex(),
             "e8df6fa40344c1fde721e9a35d46daadb48dc66f7901a9795ebb0374474ea601"


### PR DESCRIPTION
Implements `Digest` for DomainSeparatedHasher with a blank default label
Deleted `GenericHashDomain`

Motivation
---
This means you can use a DomainSeparatedHasher in any function that already uses Digest. Unfortunately, the label must be blank, so the `domain` should be different for struct.

I also added a macro `hashing_domain` for creating domains quickly (e.g. for tests)

```rust
hash_domain!(MyDemoHasher, "macro.test");
// Generates

 pub struct MyDemoHasher {}

        impl DomainSeparation for MyDemoHasher {
            fn version() -> u8 {
                1
            }

            fn domain() -> &'static str {
                "macro.test"
            }
        }   

   
``` 

After adding the `hash_domain` macro it is now easy enough to create a new domain when you need it, removing the need for `GenericHashDomain`. I found that devs were trying to build on top of it instead of creating new domains, so IMO it's more confusing keeping it in     

UPDATE: Removed `GenericHashDomain`
UPDATE: Added `create_hasher!` macro 