### PR TITLE
feat: add hasher macro

### DIFF
--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -482,25 +482,31 @@ macro_rules! hash_domain {
     };
 }
 
-/// Creates a domain separated hasher.
+/// Creates a domain separated hasher type and domain in one
 #[macro_export]
-macro_rules! create_hasher {
-    ($digest:ty, $name:ident, $domain:expr, $label:expr, $version: expr) => {{
-        use $crate::hash_domain;
+macro_rules! hasher {
+    ($digest:ty, $name:ident, $domain:expr, $version: expr, $mod_name:ident) => {
+        mod $mod_name {
+            use $crate::hash_domain;
 
-        hash_domain!($name, $domain, $version);
-        let hasher = $crate::hashing::DomainSeparatedHasher::<$digest, $name>::new($label);
-        hasher
-    }};
+            hash_domain!(__HashDomain, $domain, $version);
+        }
+        pub type $name = $crate::hashing::DomainSeparatedHasher<$digest, $mod_name::__HashDomain>;
+    };
     ($digest: ty, $name:ident, $domain:expr, $label:expr) => {
-        create_hasher!($digest, $name, $domain, $label, 1)
+        hasher!($digest, $name, $domain, 1, __inner);
     };
     ($digest: ty, $name:ident, $domain:expr) => {
-        create_hasher!($digest, $name, $domain, "", 1)
+        hasher!($digest, $name, $domain, 1, __inner);
     };
     ($digest: ty, $domain:expr) => {
-        create_hasher!($digest, __TempHashDomain, $domain, "", 1)
+        hasher!($digest, __TempHashDomain, $domain, 1, __inner);
     };
+}
+
+/// Convenience function for creating a DomainSeparatedHasher
+pub fn create_hasher<D: Digest, HD: DomainSeparation>(label: &'static str) -> DomainSeparatedHasher<D, HD> {
+    DomainSeparatedHasher::<D, HD>::new(label)
 }
 
 #[cfg(test)]
@@ -533,22 +539,25 @@ mod test {
     }
 
     #[test]
-    fn create_hasher_macro_tests() {
-        util::hash_from_digest(
-            create_hasher!(Blake256, MyDemoHasher, "com.macro.test", "", 1),
-            &[0, 0, 0],
-            "5faa7d48b551362bbee8a02c43e6ab634ed47c58ecf7b353f9afedfe3d574608",
-        );
-        util::hash_from_digest(
-            create_hasher!(Blake256, MyDemoHasher, "com.macro.test"),
-            &[0, 0, 0],
-            "5faa7d48b551362bbee8a02c43e6ab634ed47c58ecf7b353f9afedfe3d574608",
-        );
-        util::hash_from_digest(
-            create_hasher!(Blake256, "com.macro.test"),
-            &[0, 0, 0],
-            "5faa7d48b551362bbee8a02c43e6ab634ed47c58ecf7b353f9afedfe3d574608",
-        );
+    fn hasher_macro_tests() {
+        {
+            hasher!(Blake256, MyDemoHasher, "com.macro.test");
+
+            util::hash_from_digest(
+                MyDemoHasher::new(""),
+                &[0, 0, 0],
+                "5faa7d48b551362bbee8a02c43e6ab634ed47c58ecf7b353f9afedfe3d574608",
+            );
+        }
+        {
+            hasher!(Blake256, MyDemoHasher2, "com.macro.test", "");
+
+            util::hash_from_digest(
+                MyDemoHasher2::new(""),
+                &[0, 0, 0],
+                "5faa7d48b551362bbee8a02c43e6ab634ed47c58ecf7b353f9afedfe3d574608",
+            );
+        }
     }
 
     #[test]

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -494,10 +494,10 @@ macro_rules! hasher {
         pub type $name = $crate::hashing::DomainSeparatedHasher<$digest, $mod_name::__HashDomain>;
     };
     ($digest: ty, $name:ident, $domain:expr, $version: expr) => {
-        hasher!($digest, $name, $domain, $version, __inner);
+        hasher!($digest, $name, $domain, $version, __inner_hasher_impl);
     };
     ($digest: ty, $name:ident, $domain:expr) => {
-        hasher!($digest, $name, $domain, 1, __inner);
+        hasher!($digest, $name, $domain, 1, __inner_hasher_impl);
     };
 }
 

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -493,14 +493,11 @@ macro_rules! hasher {
         }
         pub type $name = $crate::hashing::DomainSeparatedHasher<$digest, $mod_name::__HashDomain>;
     };
-    ($digest: ty, $name:ident, $domain:expr, $label:expr) => {
-        hasher!($digest, $name, $domain, 1, __inner);
+    ($digest: ty, $name:ident, $domain:expr, $version: expr) => {
+        hasher!($digest, $name, $domain, $version, __inner);
     };
     ($digest: ty, $name:ident, $domain:expr) => {
         hasher!($digest, $name, $domain, 1, __inner);
-    };
-    ($digest: ty, $domain:expr) => {
-        hasher!($digest, __TempHashDomain, $domain, 1, __inner);
     };
 }
 
@@ -550,7 +547,7 @@ mod test {
             );
         }
         {
-            hasher!(Blake256, MyDemoHasher2, "com.macro.test", "");
+            hasher!(Blake256, MyDemoHasher2, "com.macro.test", 1);
 
             util::hash_from_digest(
                 MyDemoHasher2::new(""),

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -258,7 +258,7 @@ impl RistrettoPublicKey {
     }
 
     /// A verifiable group generator using a domain separated hasher
-    pub fn new_generator(label: &str) -> Result<RistrettoPublicKey, HashingError> {
+    pub fn new_generator(label: &'static str) -> Result<RistrettoPublicKey, HashingError> {
         // This function requires 512 bytes of data, so let's be opinionated here and use blake2b
         let hash = DomainSeparatedHasher::<Blake2b, RistrettoGeneratorPoint>::new(label).finalize();
         if hash.as_ref().len() < 64 {
@@ -803,7 +803,7 @@ mod test {
 
     #[test]
     fn kdf_key_too_short() {
-        let err = RistrettoKdf::generate::<Blake256, _>(b"this_key_is_too_short", b"data", "test").err();
+        let err = RistrettoKdf::generate::<Blake256>(b"this_key_is_too_short", b"data", "test").err();
         assert!(matches!(err, Some(HashingError::InputTooShort)));
     }
 
@@ -811,8 +811,8 @@ mod test {
     fn kdf_test() {
         let key =
             RistrettoSecretKey::from_hex("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c").unwrap();
-        let derived1 = RistrettoKdf::generate::<Blake256, _>(key.as_bytes(), b"derived1", "test").unwrap();
-        let derived2 = RistrettoKdf::generate::<Blake256, _>(key.as_bytes(), b"derived2", "test").unwrap();
+        let derived1 = RistrettoKdf::generate::<Blake256>(key.as_bytes(), b"derived1", "test").unwrap();
+        let derived2 = RistrettoKdf::generate::<Blake256>(key.as_bytes(), b"derived2", "test").unwrap();
         assert_eq!(
             derived1.to_hex(),
             "e8df6fa40344c1fde721e9a35d46daadb48dc66f7901a9795ebb0374474ea601"


### PR DESCRIPTION
Changed `create_hasher!` macro into a helper function instead, since in most cases you want to reuse the domain created.

Created a macro for creating a type aliased hasher and domain in one called `hasher!` 

e.g.
```
 hasher!(Blake256, MyDemoHasher, "com.macro.test");

 MyDemoHasher::new("label").chain(data).finalize();
```