### PR TITLE
chore: upgrade tari_utilities version to 0.4.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.15.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.4" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.5" }
 
 base64 = "0.10.1"
 blake2 = "0.9.1"


### PR DESCRIPTION
Upgrade `tari-utilities` dependency to `0.4.5` version.