### PR TITLE
feat: synchronize the standard digest `new()` with `domain separated hasher::new()`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,7 +39,7 @@ pub enum CommitmentError {
 }
 
 /// Errors encountered when hashing
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum HashingError {
     /// The input to the hashing function is too short
     #[error("The input to the hashing function is too short.")]
@@ -50,4 +50,12 @@ pub enum HashingError {
     /// The digest does not produce enough output
     #[error("The digest does produce enough output. {0} bytes are required.")]
     DigestTooShort(usize),
+}
+
+/// Errors encountered when copying to a buffer
+#[derive(Debug, Clone, Error, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SliceError {
+    /// The requested fixed slice length exceeds the available slice length
+    #[error("Cannot create fixed slice of length {0} from a slice of length {1}.")]
+    CopyFromSlice(usize, usize),
 }

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -260,7 +260,7 @@ impl RistrettoPublicKey {
     /// A verifiable group generator using a domain separated hasher
     pub fn new_generator(label: &'static str) -> Result<RistrettoPublicKey, HashingError> {
         // This function requires 512 bytes of data, so let's be opinionated here and use blake2b
-        let hash = DomainSeparatedHasher::<Blake2b, RistrettoGeneratorPoint>::new(label).finalize();
+        let hash = DomainSeparatedHasher::<Blake2b, RistrettoGeneratorPoint>::new_with_label(label).finalize();
         if hash.as_ref().len() < 64 {
             return Err(HashingError::DigestTooShort(64));
         }


### PR DESCRIPTION
With applying the new hashing API in the tari project some some suggestions are made to improve its use-ability:

- Renamed `DomainSeparatedHasher::<D, M>::new()` to   `DomainSeparatedHasher::<D, M>::new_with_label(label: &'static str)`
- Added `DomainSeparatedHasher<D, M>::new()` to to be functionally equivalent to `D::new()` due to use of `<DomainSeparatedHasher<D, M> as Digest>`
- Added `pub trait HashToBytes`
- Added a digest convenience function to the hashing API

_**Note:** The new error type `SliceError` must be `serde::{Deserialize, Serialize}` compatible and can therefor not be included in `HashingError`_