### PR TITLE
feat(hashing): eager implement common traits

### DIFF
--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -511,7 +511,8 @@ pub trait DerivedKeyDomain: DomainSeparation {
 #[macro_export]
 macro_rules! hash_domain {
     ($name:ident, $domain:expr, $version: expr) => {
-        pub struct $name {}
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name;
 
         impl $crate::hashing::DomainSeparation for $name {
             fn version() -> u8 {


### PR DESCRIPTION
As per https://rust-lang.github.io/api-guidelines/interoperability.html

When using the hash domain in structs, most commonly with `#derive(Debug, Clone)]`, the code fails to compile
and manual implementations are required.