### PR TITLE
fix: update commitment signature

### DIFF
--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -64,7 +64,7 @@ pub trait DomainSeparation {
         if !label.as_ref().is_empty() {
             return format!("{}.v{}.{}", Self::domain(), Self::version(), label.as_ref());
         }
-        return format!("{}.v{}", Self::domain(), Self::version());
+        format!("{}.v{}", Self::domain(), Self::version())
     }
 
     /// Adds the domain separation tag to the given digest. The domain separation tag is defined as

--- a/src/ristretto/ristretto_com_sig.rs
+++ b/src/ristretto/ristretto_com_sig.rs
@@ -6,14 +6,14 @@ use crate::{
     signatures::CommitmentSignature,
 };
 
-/// # A Commitment signature implementation on Ristretto
+/// # A commitment signature implementation on Ristretto
 ///
 /// `RistrettoComSig` utilises the [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek1)
-/// implementation of `ristretto255` to provide Commitment Signature functionality utlizing Schnorr signatures.
+/// implementation of `ristretto255` to provide commitment signature functionality.
 ///
 /// ## Examples
 ///
-/// You can create a `RistrettoComSig` from it's component parts:
+/// You can create a `RistrettoComSig` from its component parts:
 ///
 /// ```edition2018
 /// # use tari_crypto::ristretto::*;
@@ -29,8 +29,8 @@ use crate::{
 /// let sig = RistrettoComSig::new(r_pub, u, v);
 /// ```
 ///
-/// or you can create a signature for a commitment by signing a message with knowledge of the commitment and then
-/// verify it by calling the `verify_challenge` method:
+/// or you can create a signature for a commitment by signing a message with knowledge of the commitment and
+/// commitment to zero, and then verify it by calling the `verify_challenge` method:
 ///
 /// ```rust
 /// # use tari_crypto::ristretto::*;
@@ -45,43 +45,20 @@ use crate::{
 /// let mut rng = rand::thread_rng();
 /// let a_val = RistrettoSecretKey::random(&mut rng);
 /// let x_val = RistrettoSecretKey::random(&mut rng);
+/// let y_val = RistrettoSecretKey::random(&mut rng);
 /// let a_nonce = RistrettoSecretKey::random(&mut rng);
 /// let x_nonce = RistrettoSecretKey::random(&mut rng);
-/// let e = Blake256::digest(b"Maskerade");
+/// let e = Blake256::digest(b"Maskerade"); // implementations should use Fiat-Shamir data binding!
 /// let factory = PedersenCommitmentFactory::default();
 /// let commitment = factory.commit(&x_val, &a_val);
+/// let commitment_to_zero = factory
+///     .commit(&y_val, &RistrettoSecretKey::default())
+///     .as_public_key()
+///     .to_owned();
 /// // println!("commitment: {:?}", commitment.to_hex());
-/// let sig = RistrettoComSig::sign(&a_val, &x_val, &a_nonce, &x_nonce, &e, &factory).unwrap();
+/// let sig = RistrettoComSig::sign(&a_val, &x_val, &y_val, &a_nonce, &x_nonce, &e, &factory).unwrap();
 /// // println!("sig: R {:?} u {:?} v {:?}", sig.public_nonce().to_hex(), sig.u().to_hex(), sig.v().to_hex());
-/// assert!(sig.verify_challenge(&commitment, &e, &factory));
-/// ```
-///
-/// # Verifying signatures
-///
-/// Given a signature, (R,u,v), a commitment C and a Challenge, e, you can verify that the signature is valid by
-/// calling the `verify_challenge` method:
-///
-/// ```edition2018
-/// # use tari_crypto::ristretto::*;
-/// # use tari_crypto::keys::*;
-/// # use tari_crypto::commitment::HomomorphicCommitment;
-/// # use tari_crypto::ristretto::pedersen::*;
-/// # use tari_crypto::hash::blake2::Blake256;
-/// # use tari_utilities::hex::*;
-/// # use tari_utilities::ByteArray;
-/// # use digest::Digest;
-/// use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
-///
-/// let commitment =
-///     HomomorphicCommitment::from_hex("167c6df11bf8106e89328c297e57423dc2a9be53df1ee63f6e50b4610104ab4a").unwrap();
-/// let r_nonce =
-///     HomomorphicCommitment::from_hex("4033e00996e61df2ea1abd1494b751b946663e21a20e2729c6592712beb15356").unwrap();
-/// let u = RistrettoSecretKey::from_hex("f44bbc3374b172f77ffa8b904ddf0ad9f879b3e6183f9e440c57e7f01e851300").unwrap();
-/// let v = RistrettoSecretKey::from_hex("fd54afb2d8008c8a3af10272b24161247b2b7ae11687813fe9fb03e34dd7f009").unwrap();
-/// let sig = RistrettoComSig::new(r_nonce, u, v);
-/// let e = Blake256::digest(b"Maskerade");
-/// let factory = PedersenCommitmentFactory::default();
-/// assert!(sig.verify_challenge(&commitment, &e, &factory));
+/// assert!(sig.verify_challenge(&commitment, &commitment_to_zero, &e, &factory));
 /// ```
 pub type RistrettoComSig = CommitmentSignature<RistrettoPublicKey, RistrettoSecretKey>;
 
@@ -121,8 +98,13 @@ mod test {
         let mut rng = rand::thread_rng();
         let a_value = RistrettoSecretKey::random(&mut rng);
         let x_value = RistrettoSecretKey::random(&mut rng);
+        let y_value = RistrettoSecretKey::random(&mut rng);
         let factory = PedersenCommitmentFactory::default();
         let commitment = factory.commit(&x_value, &a_value);
+        let commitment_to_zero = factory
+            .commit(&y_value, &RistrettoSecretKey::default())
+            .as_public_key()
+            .to_owned();
 
         let k_1 = RistrettoSecretKey::random(&mut rng);
         let k_2 = RistrettoSecretKey::random(&mut rng);
@@ -130,23 +112,24 @@ mod test {
 
         let challenge = Blake256::new()
             .chain(commitment.as_bytes())
+            .chain(commitment_to_zero.as_bytes())
             .chain(nonce_commitment.as_bytes())
             .chain(b"Small Gods")
             .finalize();
         let e_key = RistrettoSecretKey::from_bytes(&challenge).unwrap();
-        let u_value = &k_1 + e_key.clone() * &x_value;
+        let u_value = &k_1 + e_key.clone() * &x_value + e_key.clone() * e_key.clone() * &y_value;
         let v_value = &k_2 + e_key * &a_value;
-        let sig = RistrettoComSig::sign(&a_value, &x_value, &k_2, &k_1, &challenge, &factory).unwrap();
+        let sig = RistrettoComSig::sign(&a_value, &x_value, &y_value, &k_2, &k_1, &challenge, &factory).unwrap();
         let R_calc = sig.public_nonce();
         assert_eq!(nonce_commitment, *R_calc);
         let (_, sig_1, sig_2) = sig.complete_signature_tuple();
         assert_eq!((sig_1, sig_2), (&u_value, &v_value));
-        assert!(sig.verify_challenge(&commitment, &challenge, &factory));
+        assert!(sig.verify_challenge(&commitment, &commitment_to_zero, &challenge, &factory));
         // Doesn't work for invalid credentials
-        assert!(!sig.verify_challenge(&nonce_commitment, &challenge, &factory));
+        assert!(!sig.verify_challenge(&nonce_commitment, &commitment_to_zero, &challenge, &factory));
         // Doesn't work for different challenge
         let wrong_challenge = Blake256::digest(b"Guards! Guards!");
-        assert!(!sig.verify_challenge(&commitment, &wrong_challenge, &factory));
+        assert!(!sig.verify_challenge(&commitment, &commitment_to_zero, &wrong_challenge, &factory));
     }
 
     /// This test checks that the linearity of commitment Schnorr signatures hold, i.e. that s = s1 + s2 is validated by
@@ -159,21 +142,33 @@ mod test {
         // Alice generate some keys and nonces
         let a_value_alice = RistrettoSecretKey::random(&mut rng);
         let x_value_alice = RistrettoSecretKey::random(&mut rng);
+        let y_value_alice = RistrettoSecretKey::random(&mut rng);
         let commitment_alice = factory.commit(&x_value_alice, &a_value_alice);
+        let commitment_to_zero_alice = factory
+            .commit(&y_value_alice, &RistrettoSecretKey::default())
+            .as_public_key()
+            .to_owned();
         let k_1_alice = RistrettoSecretKey::random(&mut rng);
         let k_2_alice = RistrettoSecretKey::random(&mut rng);
         let nonce_commitment_alice = factory.commit(&k_1_alice, &k_2_alice);
-        // Alice generate some keys and nonces
+        // Bob generate some keys and nonces
         let a_value_bob = RistrettoSecretKey::random(&mut rng);
         let x_value_bob = RistrettoSecretKey::random(&mut rng);
+        let y_value_bob = RistrettoSecretKey::random(&mut rng);
         let commitment_bob = factory.commit(&x_value_bob, &a_value_bob);
+        let commitment_to_zero_bob = factory
+            .commit(&y_value_bob, &RistrettoSecretKey::default())
+            .as_public_key()
+            .to_owned();
         let k_1_bob = RistrettoSecretKey::random(&mut rng);
         let k_2_bob = RistrettoSecretKey::random(&mut rng);
         let nonce_commitment_bob = factory.commit(&k_1_bob, &k_2_bob);
-        // Each of them creates the Challenge committing to both commitments of both parties
+        // Each of them creates the challenge committing to both commitments of both parties
         let challenge = Blake256::new()
             .chain(commitment_alice.as_bytes())
+            .chain(commitment_to_zero_alice.as_bytes())
             .chain(commitment_bob.as_bytes())
+            .chain(commitment_to_zero_bob.as_bytes())
             .chain(nonce_commitment_alice.as_bytes())
             .chain(nonce_commitment_bob.as_bytes())
             .chain(b"Moving Pictures")
@@ -182,6 +177,7 @@ mod test {
         let sig_alice = RistrettoComSig::sign(
             &a_value_alice,
             &x_value_alice,
+            &y_value_alice,
             &k_2_alice,
             &k_1_alice,
             &challenge,
@@ -189,13 +185,22 @@ mod test {
         )
         .unwrap();
         // Calculate Bob's signature
-        let sig_bob =
-            RistrettoComSig::sign(&a_value_bob, &x_value_bob, &k_2_bob, &k_1_bob, &challenge, &factory).unwrap();
+        let sig_bob = RistrettoComSig::sign(
+            &a_value_bob,
+            &x_value_bob,
+            &y_value_bob,
+            &k_2_bob,
+            &k_1_bob,
+            &challenge,
+            &factory,
+        )
+        .unwrap();
         // Now add the two signatures together
         let s_agg = &sig_alice + &sig_bob;
         // Check that the multi-sig verifies
         let combined_commitment = &commitment_alice + &commitment_bob;
-        assert!(s_agg.verify_challenge(&combined_commitment, &challenge, &factory));
+        let combined_commitment_to_zero = &commitment_to_zero_alice + &commitment_to_zero_bob;
+        assert!(s_agg.verify_challenge(&combined_commitment, &combined_commitment_to_zero, &challenge, &factory));
     }
 
     /// Ristretto scalars have a max value 2^255. This test checks that hashed messages above this value can still be
@@ -206,10 +211,11 @@ mod test {
         let factory = PedersenCommitmentFactory::default();
         let a_value = RistrettoSecretKey::random(&mut rng);
         let x_value = RistrettoSecretKey::random(&mut rng);
+        let y_value = RistrettoSecretKey::random(&mut rng);
         let message = from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
         let k_1 = RistrettoSecretKey::random(&mut rng);
         let k_2 = RistrettoSecretKey::random(&mut rng);
-        assert!(RistrettoComSig::sign(&a_value, &x_value, &k_2, &k_1, &message, &factory).is_ok());
+        assert!(RistrettoComSig::sign(&a_value, &x_value, &y_value, &k_2, &k_1, &message, &factory).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
The commitment signature is special sound as a zero-knowledge proof of knowledge of the opening of a commitment, and can be bound to an arbitrary message for use as a signature construction.

However, in practice there are two input commitments used by the prover and verifier: a standard Pedersen commitment and an additional commitment to zero (either a sender offset or script public key). These commitments are summed and, while they are included separately in the Fiat-Shamir transcript, successful verification does not imply prover knowledge of both commitment openings separately.

While it is possible to update the commitment signature construction using a standard Chaum-Pedersen construction, this would increase the signature size. Another approach is to use a power-of-challenge design that retains the same signature size. This PR uses the latter approach, and updates tests and documentation accordingly. The commitment to zero is handled as a public key, but it remains the caller's responsibility to ensure it uses the correct generator. As before, the Fiat-Shamir transcript does _not_ bind to generators, assuming they are public and globally fixed.

It is worth noting that a future use of the commitment signature may not need to prove knowledge of the opening of a commitment to zero; in this case, it suffices to use zero values for the public key and corresponding witness.