### PR TITLE
feat: add new commitment signature to use complete representation proof

### DIFF
--- a/src/ffi/keys.rs
+++ b/src/ffi/keys.rs
@@ -357,19 +357,17 @@ pub unsafe extern "C" fn verify_comandpubsig(
         *err_code = NULL_POINTER;
         return false;
     }
-    let commitment = match HomomorphicCommitment::from_bytes(&(*commitment)) {
-        Ok(k) => k,
-        _ => {
-            *err_code = INVALID_SECRET_KEY_SER;
-            return false;
-        },
+    let commitment = if let Ok(k) = HomomorphicCommitment::from_bytes(&(*commitment)) {
+        k
+    } else {
+        *err_code = INVALID_SECRET_KEY_SER;
+        return false;
     };
-    let pubkey = match RistrettoPublicKey::from_bytes(&(*pubkey)) {
-        Ok(k) => k,
-        _ => {
-            *err_code = INVALID_SECRET_KEY_SER;
-            return false;
-        },
+    let pubkey = if let Ok(k) = RistrettoPublicKey::from_bytes(&(*pubkey)) {
+        k
+    } else {
+        *err_code = INVALID_SECRET_KEY_SER;
+        return false;
     };
     let ephemeral_commitment = match HomomorphicCommitment::from_bytes(&(*ephemeral_commitment)) {
         Ok(r) => r,

--- a/src/ffi/keys.rs
+++ b/src/ffi/keys.rs
@@ -402,7 +402,7 @@ pub unsafe extern "C" fn verify_comandpubsig(
         _ => return false,
     };
     let factory = PedersenCommitmentFactory::default();
-    sig.verify(&commitment, &pubkey, &challenge, &factory)
+    sig.verify(&commitment, &pubkey, &challenge, &factory, &mut OsRng)
 }
 
 #[cfg(test)]

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -9,7 +9,7 @@ mod error;
 mod keys;
 
 pub use error::lookup_error_message;
-pub use keys::{commitment, random_keypair, sign, sign_comsig, verify, verify_comsig};
+pub use keys::{commitment, random_keypair, sign, sign_comsig, sign_comandpubsig, verify, verify_comsig, verify_comandpubsig};
 
 const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "\u{00}");
 

--- a/src/ristretto/mod.rs
+++ b/src/ristretto/mod.rs
@@ -7,6 +7,7 @@ pub mod bulletproofs_plus;
 pub mod constants;
 mod dalek_range_proof;
 pub mod pedersen;
+mod ristretto_com_and_pub_sig;
 mod ristretto_com_sig;
 pub mod ristretto_keys;
 mod ristretto_sig;
@@ -17,6 +18,7 @@ pub mod utils;
 pub use dalek_range_proof::DalekRangeProofService;
 
 pub use self::{
+    ristretto_com_and_pub_sig::RistrettoComAndPubSig,
     ristretto_com_sig::RistrettoComSig,
     ristretto_keys::{RistrettoPublicKey, RistrettoSecretKey},
     ristretto_sig::RistrettoSchnorr,

--- a/src/ristretto/ristretto_com_and_pub_sig.rs
+++ b/src/ristretto/ristretto_com_and_pub_sig.rs
@@ -57,7 +57,7 @@ use crate::{
 /// let commitment = factory.commit(&x_val, &a_val);
 /// let pubkey = RistrettoPublicKey::from_secret_key(&y_val);
 /// let sig = RistrettoComAndPubSig::sign(&a_val, &x_val, &y_val, &a_nonce, &x_nonce, &y_nonce, &e, &factory).unwrap();
-/// assert!(sig.verify_challenge(&commitment, &pubkey, &e, &factory));
+/// assert!(sig.verify_challenge(&commitment, &pubkey, &e, &factory, &mut rng));
 /// ```
 pub type RistrettoComAndPubSig = CommitmentAndPublicKeySignature<RistrettoPublicKey, RistrettoSecretKey>;
 
@@ -156,12 +156,12 @@ mod test {
         let evil_y = RistrettoSecretKey::random(&mut rng);
         let evil_pubkey = RistrettoPublicKey::from_secret_key(&evil_y);
 
-        assert!(!sig.verify_challenge(&evil_commitment, &pubkey, &challenge, &factory));
-        assert!(!sig.verify_challenge(&commitment, &evil_pubkey, &challenge, &factory));
+        assert!(!sig.verify_challenge(&evil_commitment, &pubkey, &challenge, &factory, &mut rng));
+        assert!(!sig.verify_challenge(&commitment, &evil_pubkey, &challenge, &factory, &mut rng));
 
         // A different challenge should fail
         let evil_challenge = Blake256::digest(b"Guards! Guards!");
-        assert!(!sig.verify_challenge(&commitment, &pubkey, &evil_challenge, &factory));
+        assert!(!sig.verify_challenge(&commitment, &pubkey, &evil_challenge, &factory, &mut rng));
     }
 
     /// Test that commitment signatures are linear, as in a multisignature construction
@@ -236,7 +236,7 @@ mod test {
         // The signature should verify against the sum of statement values
         let commitment_sum = &commitment_alice + &commitment_bob;
         let pubkey_sum = &pubkey_alice + &pubkey_bob;
-        assert!(sig_sum.verify_challenge(&commitment_sum, &pubkey_sum, &challenge, &factory))
+        assert!(sig_sum.verify_challenge(&commitment_sum, &pubkey_sum, &challenge, &factory, &mut rng))
     }
 
     /// Ristretto scalars have a max value 2^255. This test checks that hashed messages above this value can still be

--- a/src/ristretto/ristretto_com_and_pub_sig.rs
+++ b/src/ristretto/ristretto_com_and_pub_sig.rs
@@ -1,0 +1,274 @@
+// Copyright 2021. The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use crate::{
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    signatures::CommitmentAndPublicKeySignature,
+};
+
+/// # A commitment and public key (CAPK) signature implementation on Ristretto
+///
+/// `RistrettoComAndPubSig` utilises the [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek1)
+/// implementation of `ristretto255` to provide CAPK signature functionality.
+///
+/// ## Examples
+///
+/// You can create a `RistrettoComAndPubSig` from its component parts:
+///
+/// ```edition2018
+/// # use tari_crypto::ristretto::*;
+/// # use tari_crypto::keys::*;
+/// # use tari_crypto::commitment::HomomorphicCommitment;
+/// # use tari_utilities::ByteArray;
+/// # use tari_utilities::hex::Hex;
+///
+/// let ephemeral_commitment =
+///     HomomorphicCommitment::from_hex("8063d85e151abee630e643e2b3dc47bfaeb8aa859c9d10d60847985f286aad19").unwrap();
+/// let ephemeral_pubkey =
+///     RistrettoPublicKey::from_hex("8063d85e151abee630e643e2b3dc47bfaeb8aa859c9d10d60847985f286aad19").unwrap();
+/// let u_a = RistrettoSecretKey::from_bytes(b"10000000000000000000000010000000").unwrap();
+/// let u_x = RistrettoSecretKey::from_bytes(b"a00000000000000000000000a0000000").unwrap();
+/// let u_y = RistrettoSecretKey::from_bytes(b"a00000000000000000000000a0000000").unwrap();
+/// let sig = RistrettoComAndPubSig::new(ephemeral_commitment, ephemeral_pubkey, u_a, u_x, u_y);
+/// ```
+///
+/// or you can create a signature for a commitment by signing a message with knowledge of the commitment and then
+/// verify it by calling the `verify_challenge` method:
+///
+/// ```rust
+/// # use tari_crypto::ristretto::*;
+/// # use tari_crypto::keys::*;
+/// # use tari_crypto::hash::blake2::Blake256;
+/// # use digest::Digest;
+/// # use tari_crypto::commitment::HomomorphicCommitmentFactory;
+/// # use tari_crypto::ristretto::pedersen::*;
+/// use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
+/// use tari_utilities::hex::Hex;
+///
+/// let mut rng = rand::thread_rng();
+/// let a_val = RistrettoSecretKey::random(&mut rng);
+/// let x_val = RistrettoSecretKey::random(&mut rng);
+/// let y_val = RistrettoSecretKey::random(&mut rng);
+/// let a_nonce = RistrettoSecretKey::random(&mut rng);
+/// let x_nonce = RistrettoSecretKey::random(&mut rng);
+/// let y_nonce = RistrettoSecretKey::random(&mut rng);
+/// let e = Blake256::digest(b"Maskerade"); // In real life, this should be strong Fiat-Shamir!
+/// let factory = PedersenCommitmentFactory::default();
+/// let commitment = factory.commit(&x_val, &a_val);
+/// let pubkey = RistrettoPublicKey::from_secret_key(&y_val);
+/// let sig = RistrettoComAndPubSig::sign(&a_val, &x_val, &y_val, &a_nonce, &x_nonce, &y_nonce, &e, &factory).unwrap();
+/// assert!(sig.verify_challenge(&commitment, &pubkey, &e, &factory));
+/// ```
+pub type RistrettoComAndPubSig = CommitmentAndPublicKeySignature<RistrettoPublicKey, RistrettoSecretKey>;
+
+#[cfg(test)]
+mod test {
+    use digest::Digest;
+    use tari_utilities::{hex::from_hex, ByteArray};
+
+    use crate::{
+        commitment::HomomorphicCommitmentFactory,
+        hash::blake2::Blake256,
+        keys::{PublicKey, SecretKey},
+        ristretto::{
+            pedersen::{commitment_factory::PedersenCommitmentFactory, PedersenCommitment},
+            RistrettoComAndPubSig,
+            RistrettoPublicKey,
+            RistrettoSecretKey,
+        },
+    };
+
+    #[test]
+    fn default() {
+        let sig = RistrettoComAndPubSig::default();
+
+        // Check all values returned from the tuple
+        assert_eq!(
+            sig.complete_signature_tuple(),
+            (&PedersenCommitment::default(), &RistrettoPublicKey::default(), &RistrettoSecretKey::default(), &RistrettoSecretKey::default(), &RistrettoSecretKey::default())
+        );
+
+        // Check all values returned from the getters
+        assert_eq!(sig.ephemeral_commitment(), &PedersenCommitment::default());
+        assert_eq!(sig.ephemeral_pubkey(), &RistrettoPublicKey::default());
+        assert_eq!(sig.u_a(), &RistrettoSecretKey::default());
+        assert_eq!(sig.u_x(), &RistrettoSecretKey::default());
+        assert_eq!(sig.u_y(), &RistrettoSecretKey::default());
+    }
+
+    /// Create a signature, and then verify it. Also checks that some invalid signatures fail to verify
+    #[test]
+    fn sign_and_verify_message() {
+        let mut rng = rand::thread_rng();
+
+        // Witness data
+        let a_value = RistrettoSecretKey::random(&mut rng);
+        let x_value = RistrettoSecretKey::random(&mut rng);
+        let y_value = RistrettoSecretKey::random(&mut rng);
+
+        // Statement data
+        let factory = PedersenCommitmentFactory::default();
+        let commitment = factory.commit(&x_value, &a_value);
+        let pubkey = RistrettoPublicKey::from_secret_key(&y_value);
+
+        // Nonce data
+        let r_a = RistrettoSecretKey::random(&mut rng);
+        let r_x = RistrettoSecretKey::random(&mut rng);
+        let r_y = RistrettoSecretKey::random(&mut rng);
+        let ephemeral_commitment = factory.commit(&r_x, &r_a);
+        let ephemeral_pubkey = RistrettoPublicKey::from_secret_key(&r_y);
+
+        // Challenge; doesn't use proper Fiat-Shamir, so it's for testing only!
+        let challenge = Blake256::new()
+            .chain(commitment.as_bytes())
+            .chain(pubkey.as_bytes())
+            .chain(ephemeral_commitment.as_bytes())
+            .chain(ephemeral_pubkey.as_bytes())
+            .chain(b"Small Gods")
+            .finalize();
+        let e_key = RistrettoSecretKey::from_bytes(&challenge).unwrap();
+
+        // Responses
+        let u_a = &r_a + e_key.clone() * &a_value;
+        let u_x = &r_x + e_key.clone() * &x_value;
+        let u_y = &r_y + e_key * &y_value;
+
+        let sig = RistrettoComAndPubSig::sign(&a_value, &x_value, &y_value, &r_a, &r_x, &r_y, &challenge, &factory).unwrap();
+
+        // Check values from getters
+        assert_eq!(*sig.ephemeral_commitment(), ephemeral_commitment);
+        assert_eq!(*sig.ephemeral_pubkey(), ephemeral_pubkey);
+        assert_eq!(*sig.u_a(), u_a);
+        assert_eq!(*sig.u_x(), u_x);
+        assert_eq!(*sig.u_y(), u_y);
+
+        // Check values from tuple
+        assert_eq!(
+            sig.complete_signature_tuple(),
+            (&ephemeral_commitment, &ephemeral_pubkey, &u_a, &u_x, &u_y)
+        );
+
+        // A different statement should fail
+        let evil_a = RistrettoSecretKey::random(&mut rng);
+        let evil_x = RistrettoSecretKey::random(&mut rng);
+        let evil_commitment = factory.commit(&evil_x, &evil_a);
+
+        let evil_y = RistrettoSecretKey::random(&mut rng);
+        let evil_pubkey = RistrettoPublicKey::from_secret_key(&evil_y);
+
+        assert!(!sig.verify_challenge(&evil_commitment, &pubkey, &challenge, &factory));
+        assert!(!sig.verify_challenge(&commitment, &evil_pubkey, &challenge, &factory));
+
+        // A different challenge should fail
+        let evil_challenge = Blake256::digest(b"Guards! Guards!");
+        assert!(!sig.verify_challenge(&commitment, &pubkey, &evil_challenge, &factory));
+    }
+
+    /// Test that commitment signatures are linear, as in a multisignature construction
+    #[test]
+    fn test_signature_addition() {
+        let mut rng = rand::thread_rng();
+        let factory = PedersenCommitmentFactory::default();
+
+        // Alice's data
+        let a_value_alice = RistrettoSecretKey::random(&mut rng);
+        let x_value_alice = RistrettoSecretKey::random(&mut rng);
+        let commitment_alice = factory.commit(&x_value_alice, &a_value_alice);
+
+        let y_value_alice = RistrettoSecretKey::random(&mut rng);
+        let pubkey_alice = RistrettoPublicKey::from_secret_key(&y_value_alice);
+
+        let r_a_alice = RistrettoSecretKey::random(&mut rng);
+        let r_x_alice = RistrettoSecretKey::random(&mut rng);
+        let r_y_alice = RistrettoSecretKey::random(&mut rng);
+
+        let ephemeral_commitment_alice = factory.commit(&r_x_alice, &r_a_alice);
+        let ephemeral_pubkey_alice = RistrettoPublicKey::from_secret_key(&r_y_alice);
+        
+        // Bob's data
+        let a_value_bob = RistrettoSecretKey::random(&mut rng);
+        let x_value_bob = RistrettoSecretKey::random(&mut rng);
+        let commitment_bob = factory.commit(&x_value_bob, &a_value_bob);
+
+        let y_value_bob = RistrettoSecretKey::random(&mut rng);
+        let pubkey_bob = RistrettoPublicKey::from_secret_key(&y_value_bob);
+
+        let r_a_bob = RistrettoSecretKey::random(&mut rng);
+        let r_x_bob = RistrettoSecretKey::random(&mut rng);
+        let r_y_bob = RistrettoSecretKey::random(&mut rng);
+
+        let ephemeral_commitment_bob = factory.commit(&r_x_bob, &r_a_bob);
+        let ephemeral_pubkey_bob = RistrettoPublicKey::from_secret_key(&r_y_bob);
+        
+        // The challenge is common to Alice and Bob; here we use an arbitrary hash
+        let challenge = Blake256::digest(b"Test challenge");
+
+        // Alice's signature
+        let sig_alice = RistrettoComAndPubSig::sign(
+            &a_value_alice,
+            &x_value_alice,
+            &y_value_alice,
+            &r_a_alice,
+            &r_x_alice,
+            &r_y_alice,
+            &challenge,
+            &factory,
+        ).unwrap();
+
+        // Bob's signature
+        let sig_bob = RistrettoComAndPubSig::sign(
+            &a_value_bob,
+            &x_value_bob,
+            &y_value_bob,
+            &r_a_bob,
+            &r_x_bob,
+            &r_y_bob,
+            &challenge,
+            &factory,
+        ).unwrap();
+
+        // Add the two signatures
+        let sig_sum = &sig_alice + &sig_bob;
+
+        assert_eq!(*sig_sum.ephemeral_commitment(), &ephemeral_commitment_alice + &ephemeral_commitment_bob);
+        assert_eq!(*sig_sum.ephemeral_pubkey(), &ephemeral_pubkey_alice + &ephemeral_pubkey_bob);
+
+        // The signature should verify against the sum of statement values
+        let commitment_sum = &commitment_alice + &commitment_bob;
+        let pubkey_sum = &pubkey_alice + &pubkey_bob;
+        assert!(sig_sum.verify_challenge(&commitment_sum, &pubkey_sum, &challenge, &factory))
+    }
+
+    /// Ristretto scalars have a max value 2^255. This test checks that hashed messages above this value can still be
+    /// signed as a result of applying modulo arithmetic on the challenge value
+    #[test]
+    fn challenge_from_invalid_scalar() {
+        let mut rng = rand::thread_rng();
+        let factory = PedersenCommitmentFactory::default();
+
+        let a_value = RistrettoSecretKey::random(&mut rng);
+        let x_value = RistrettoSecretKey::random(&mut rng);
+        let y_value = RistrettoSecretKey::random(&mut rng);
+
+        let message = from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
+
+        let r_a = RistrettoSecretKey::random(&mut rng);
+        let r_x = RistrettoSecretKey::random(&mut rng);
+        let r_y = RistrettoSecretKey::random(&mut rng);
+
+        assert!(RistrettoComAndPubSig::sign(&a_value, &x_value, &y_value, &r_a, &r_x, &r_y, &message, &factory).is_ok());
+    }
+
+    #[test]
+    fn to_vec() {
+        let sig = RistrettoComAndPubSig::default();
+        let bytes = sig.to_vec();
+
+        assert_eq!(
+            bytes.capacity(),
+            2*RistrettoPublicKey::key_length() + 3*RistrettoSecretKey::key_length()
+        );
+        assert_eq!(bytes.capacity(), bytes.len());
+        assert!(bytes.iter().all(|b| *b == 0x00));
+    }
+}

--- a/src/signatures/commitment_and_public_key_signature.rs
+++ b/src/signatures/commitment_and_public_key_signature.rs
@@ -1,0 +1,349 @@
+// Copyright 2021. The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    cmp::Ordering,
+    hash::{Hash, Hasher},
+    ops::{Add, Mul},
+};
+
+use rand::thread_rng;
+use serde::{Deserialize, Serialize};
+use tari_utilities::ByteArray;
+use thiserror::Error;
+
+use crate::{
+    commitment::{HomomorphicCommitment, HomomorphicCommitmentFactory},
+    keys::{PublicKey, SecretKey},
+};
+
+/// An error when creating a commitment signature
+#[derive(Clone, Debug, Error, PartialEq, Eq, Deserialize, Serialize)]
+#[allow(missing_docs)]
+pub enum CommitmentAndPublicKeySignatureError {
+    #[error("An invalid challenge was provided")]
+    InvalidChallenge,
+}
+
+/// # Commitment and public key (CAPK) signatures
+/// 
+/// Given a commitment `commitment = a*H + x*G` and group element `pubkey = y*G`, a CAPK signature is based on
+/// a representation proof of both openings: `(a, x)` and `y`. It additionally binds to arbitrary message data `m`
+/// via the challenge to produce a signature construction.
+/// 
+/// It is used in Tari protocols as part of transaction authorization.
+/// 
+/// The construction works as follows:
+/// - Sample scalar nonces `r_a, r_x, r_y` uniformly at random.
+/// - Compute ephemeral values `ephemeral_commitment = r_a*H + r_x*G` and `ephemeral_pubkey = r_y*G`.
+/// - Use strong Fiat-Shamir to produce a challenge `e`. If `e == 0` (this is unlikely), abort and start over.
+/// - Compute the responses `u_a = r_a + e*a` and `u_x = r_x + e*x` and `u_y = r_y + e*y`.
+/// 
+/// The signature is the tuple `(ephemeral_commitment, ephemeral_pubkey, u_a, u_x, u_y)`.
+/// 
+/// To verify:
+/// - The verifier computes the challenge `e` and rejects the signature if `e == 0` (this is unlikely).
+/// - Verification succeeds if and only if the following equations hold:
+///     `u_a*H + u*x*G == ephemeral_commitment + e*commitment`
+///     `u_y*G == ephemeral_pubkey + e*pubkey`
+/// 
+/// We note that it is possible to make verification slightly more efficient. To do so, the verifier selects a nonzero
+/// scalar weight `w` uniformly at random (not through Fiat-Shamir!) and accepts the signature if and only if the
+/// following equation holds:
+///     `u_a*H + (u_x + w*u_y)*G - ephemeral_commitment - w*ephemeral_pubkey - e*commitment - (w*e)*pubkey == 0`
+/// The use of efficient multiscalar multiplication algorithms may also be useful for efficiency.
+/// The use of precomputation tables for `G` and `H` may also be useful for efficiency.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitmentAndPublicKeySignature<P, K> {
+    ephemeral_commitment: HomomorphicCommitment<P>,
+    ephemeral_pubkey: P,
+    u_a: K,
+    u_x: K,
+    u_y: K,
+}
+
+impl<P, K> CommitmentAndPublicKeySignature<P, K>
+where
+    P: PublicKey<K = K>,
+    K: SecretKey,
+{
+    /// Creates a new [CommitmentSignature]
+    pub fn new(ephemeral_commitment: HomomorphicCommitment<P>, ephemeral_pubkey: P, u_a: K, u_x: K, u_y: K) -> Self {
+        CommitmentAndPublicKeySignature { ephemeral_commitment, ephemeral_pubkey, u_a, u_x, u_y }
+    }
+
+    /// Complete a signature using the given challenge. The challenge is provided by the caller to support the
+    /// multiparty use case. It is _very important_ that it be computed using strong Fiat-Shamir! Further, the
+    /// values `r_a, r_x, r_y` are nonces, must be sampled uniformly at random, and must never be reused.
+    pub fn sign<C>(
+        a: &K,
+        x: &K,
+        y: &K,
+        r_a: &K,
+        r_x: &K,
+        r_y: &K,
+        challenge: &[u8],
+        factory: &C,
+    ) -> Result<Self, CommitmentAndPublicKeySignatureError>
+    where
+        K: Mul<P, Output = P>,
+        for<'a> &'a K: Add<&'a K, Output = K>,
+        for<'a> &'a K: Mul<&'a K, Output = K>,
+        C: HomomorphicCommitmentFactory<P = P>,
+    {
+        // The challenge must be a valid scalar
+        let e = match K::from_bytes(challenge) {
+            Ok(e) => e,
+            Err(_) => return Err(CommitmentAndPublicKeySignatureError::InvalidChallenge),
+        };
+
+        // The challenge cannot be zero
+        if e == K::default() {
+            return Err(CommitmentAndPublicKeySignatureError::InvalidChallenge);
+        }
+
+        // Compute the response values
+        let ea = &e * a;
+        let ex = &e * x;
+        let ey = &e * y;
+
+        let u_a = r_a + &ea;
+        let u_x = r_x + &ex;
+        let u_y = r_y + &ey;
+
+        // Compute the initial values
+        let ephemeral_commitment = factory.commit(r_x, r_a);
+        let ephemeral_pubkey = P::from_secret_key(r_y);
+
+        Ok(Self::new(ephemeral_commitment, ephemeral_pubkey, u_a, u_x, u_y))
+    }
+
+    /// Verify a signature on a commitment and group element statement using a given challenge (as a byte array)
+    pub fn verify_challenge<'a, C>(
+        &self,
+        commitment: &'a HomomorphicCommitment<P>,
+        pubkey: &'a P,
+        challenge: &[u8],
+        factory: &C,
+    ) -> bool
+    where
+        for<'b> &'a HomomorphicCommitment<P>: Mul<&'b K, Output = HomomorphicCommitment<P>>,
+        for<'b> &'b P: Mul<&'b K, Output = P>,
+        for<'b> &'b HomomorphicCommitment<P>: Add<&'b HomomorphicCommitment<P>, Output = HomomorphicCommitment<P>>,
+        for<'b> &'b P: Add<&'b P, Output = P>,
+        for<'b> &'b K: Mul<&'b K, Output = K>,
+        for<'b> &'b K: Add<&'b K, Output = K>,
+        C: HomomorphicCommitmentFactory<P = P>,
+    {
+        // The challenge must be a valid scalar
+        let e = match K::from_bytes(challenge) {
+            Ok(e) => e,
+            Err(_) => return false,
+        };
+
+        self.verify(commitment, pubkey, &e, factory)
+    }
+
+    /// Verify a signature on a commitment and group element statement using a given challenge (as a scalar)
+    pub fn verify<'a, C>(&self, commitment: &'a HomomorphicCommitment<P>, pubkey: &'a P, challenge: &K, factory: &C) -> bool
+    where
+        for<'b> &'a HomomorphicCommitment<P>: Mul<&'b K, Output = HomomorphicCommitment<P>>,
+        for<'b> &'b P: Mul<&'b K, Output = P>,
+        for<'b> &'b HomomorphicCommitment<P>: Add<&'b HomomorphicCommitment<P>, Output = HomomorphicCommitment<P>>,
+        for<'b> &'b P: Add<&'b P, Output = P>,
+        for<'b> &'b K: Mul<&'b K, Output = K>,
+        for<'b> &'b K: Add<&'b K, Output = K>,
+        C: HomomorphicCommitmentFactory<P = P>,
+    {
+        // The challenge cannot be zero
+        if *challenge == K::default() {
+            return false
+        }
+
+        // Use a single weighted equation for verification to avoid unnecessary group operations
+        // For now, we use naive multiscalar multiplication, but offload the commitment computation
+        // This allows for the use of precomputation within the commitment itself, which is more efficient
+        // TODO: use curve library (Straus/Pippenger) multiscalar multiplication with partial precomputation
+        let mut rng = thread_rng();
+        let w = K::random(&mut rng); // must be random and not Fiat-Shamir!
+
+        // u_a*H + (u_x + w*u_y)*G == ephemeral_commitment + w*ephemeral_pubkey + e*commitment + (w*e)*pubkey
+        let verifier_lhs = factory.commit(&(&self.u_x + &(&w * &self.u_y)), &self.u_a).as_public_key().to_owned();
+        let verifier_rhs_unweighted = self.ephemeral_commitment.as_public_key() + (commitment * challenge).as_public_key();
+        let verifier_rhs_weighted = &self.ephemeral_pubkey * &w + pubkey * &(&w * challenge);
+
+        verifier_lhs == verifier_rhs_unweighted + verifier_rhs_weighted
+    }
+
+    /// Get the signature tuple `(ephemeral_commitment, ephemeral_pubkey, u_a, u_x, u_y)`
+    #[inline]
+    pub fn complete_signature_tuple(&self) -> (&HomomorphicCommitment<P>, &P, &K, &K, &K) {
+        (&self.ephemeral_commitment, &self.ephemeral_pubkey, &self.u_a, &self.u_x, &self.u_y)
+    }
+
+    /// Get the response value `u_a`
+    #[inline]
+    pub fn u_a(&self) -> &K {
+        &self.u_a
+    }
+
+    /// Get the response value `u_x`
+    #[inline]
+    pub fn u_x(&self) -> &K {
+        &self.u_x
+    }
+
+    /// Get the response value `u_y`
+    #[inline]
+    pub fn u_y(&self) -> &K {
+        &self.u_y
+    }
+
+    /// Get the ephemeral commitment `ephemeral_commitment`
+    #[inline]
+    pub fn ephemeral_commitment(&self) -> &HomomorphicCommitment<P> {
+        &self.ephemeral_commitment
+    }
+
+    /// Get the ephemeral public key `ephemeral_pubkey`
+    #[inline]
+    pub fn ephemeral_pubkey(&self) -> &P {
+        &self.ephemeral_pubkey
+    }
+    
+    /// Produce a canonical byte representation of the commitment signature
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(2*P::key_length() + 3*K::key_length());
+        buf.extend_from_slice(self.ephemeral_commitment().as_bytes());
+        buf.extend_from_slice(self.ephemeral_pubkey().as_bytes());
+        buf.extend_from_slice(self.u_a().as_bytes());
+        buf.extend_from_slice(self.u_x().as_bytes());
+        buf.extend_from_slice(self.u_y().as_bytes());
+        buf
+    }
+}
+
+impl<'a, 'b, P, K> Add<&'b CommitmentAndPublicKeySignature<P, K>> for &'a CommitmentAndPublicKeySignature<P, K>
+where
+    P: PublicKey<K = K>,
+    &'a HomomorphicCommitment<P>: Add<&'b HomomorphicCommitment<P>, Output = HomomorphicCommitment<P>>,
+    &'a P: Add<&'b P, Output = P>,
+    K: SecretKey,
+    &'a K: Add<&'b K, Output = K>,
+{
+    type Output = CommitmentAndPublicKeySignature<P, K>;
+
+    fn add(self, rhs: &'b CommitmentAndPublicKeySignature<P, K>) -> CommitmentAndPublicKeySignature<P, K> {
+        let ephemeral_commitment_sum = self.ephemeral_commitment() + rhs.ephemeral_commitment();
+        let ephemeral_pubkey_sum_sum = self.ephemeral_pubkey() + rhs.ephemeral_pubkey();
+        let u_a_sum = self.u_a() + rhs.u_a();
+        let u_x_sum = self.u_x() + rhs.u_x();
+        let u_y_sum = self.u_y() + rhs.u_y();
+
+        CommitmentAndPublicKeySignature::new(ephemeral_commitment_sum, ephemeral_pubkey_sum_sum, u_a_sum, u_x_sum, u_y_sum)
+    }
+}
+
+impl<'a, P, K> Add<CommitmentAndPublicKeySignature<P, K>> for &'a CommitmentAndPublicKeySignature<P, K>
+where
+    P: PublicKey<K = K>,
+    for<'b> &'a HomomorphicCommitment<P>: Add<&'b HomomorphicCommitment<P>, Output = HomomorphicCommitment<P>>,
+    for<'b> &'a P: Add<&'b P, Output = P>,
+    K: SecretKey,
+    for<'b> &'a K: Add<&'b K, Output = K>,
+{
+    type Output = CommitmentAndPublicKeySignature<P, K>;
+
+    fn add(self, rhs: CommitmentAndPublicKeySignature<P, K>) -> CommitmentAndPublicKeySignature<P, K> {
+        let ephemeral_commitment_sum = self.ephemeral_commitment() + rhs.ephemeral_commitment();
+        let ephemeral_pubkey_sum_sum = self.ephemeral_pubkey() + rhs.ephemeral_pubkey();
+        let u_a_sum = self.u_a() + rhs.u_a();
+        let u_x_sum = self.u_x() + rhs.u_x();
+        let u_y_sum = self.u_y() + rhs.u_y();
+
+        CommitmentAndPublicKeySignature::new(ephemeral_commitment_sum, ephemeral_pubkey_sum_sum, u_a_sum, u_x_sum, u_y_sum)
+    }
+}
+
+impl<P, K> Default for CommitmentAndPublicKeySignature<P, K>
+where
+    P: PublicKey<K = K>,
+    K: SecretKey,
+{
+    fn default() -> Self {
+        CommitmentAndPublicKeySignature::new(HomomorphicCommitment::<P>::default(), P::default(), K::default(), K::default(), K::default())
+    }
+}
+
+/// Provide a canonical ordering for commitment signatures. We use byte representations of all values in this order:
+/// `ephemeral_commitment, ephemeral_pubkey, u_a, u_x, u_y`
+impl<P, K> Ord for CommitmentAndPublicKeySignature<P, K>
+where
+    P: PublicKey<K = K>,
+    K: SecretKey,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        let mut compare = self.ephemeral_commitment().cmp(other.ephemeral_commitment());
+        if compare != Ordering::Equal {
+            return compare;
+        }
+
+        compare = self.ephemeral_pubkey().cmp(other.ephemeral_pubkey());
+        if compare != Ordering::Equal {
+            return compare;
+        }
+
+        compare = self.u_a().as_bytes().cmp(other.u_a().as_bytes());
+        if compare != Ordering::Equal {
+            return compare;
+        }
+
+        compare = self.u_x().as_bytes().cmp(other.u_x().as_bytes());
+        if compare != Ordering::Equal {
+            return compare;
+        }
+
+        self.u_y().as_bytes().cmp(other.u_y().as_bytes())
+    }
+}
+
+impl<P, K> PartialOrd for CommitmentAndPublicKeySignature<P, K>
+where
+    P: PublicKey<K = K>,
+    K: SecretKey,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<P, K> PartialEq for CommitmentAndPublicKeySignature<P, K>
+where
+    P: PublicKey<K = K>,
+    K: SecretKey,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.ephemeral_commitment().eq(other.ephemeral_commitment()) &&
+        self.ephemeral_pubkey().eq(other.ephemeral_pubkey()) &&
+        self.u_a().eq(other.u_a()) &&
+        self.u_x().eq(other.u_x()) &&
+        self.u_y().eq(other.u_y())
+    }
+}
+
+impl<P, K> Eq for CommitmentAndPublicKeySignature<P, K>
+where
+    P: PublicKey<K = K>,
+    K: SecretKey,
+{
+}
+
+impl<P, K> Hash for CommitmentAndPublicKeySignature<P, K>
+where
+    P: PublicKey<K = K>,
+    K: SecretKey,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(&self.to_vec())
+    }
+}

--- a/src/signatures/commitment_and_public_key_signature.rs
+++ b/src/signatures/commitment_and_public_key_signature.rs
@@ -166,7 +166,6 @@ where
         // Use a single weighted equation for verification to avoid unnecessary group operations
         // For now, we use naive multiscalar multiplication, but offload the commitment computation
         // This allows for the use of precomputation within the commitment itself, which is more efficient
-        // TODO: use curve library (Straus/Pippenger) multiscalar multiplication with partial precomputation
         let w = K::random(rng); // must be random and not Fiat-Shamir!
 
         // u_a*H + (u_x + w*u_y)*G == ephemeral_commitment + w*ephemeral_pubkey + e*commitment + (w*e)*pubkey

--- a/src/signatures/commitment_signature.rs
+++ b/src/signatures/commitment_signature.rs
@@ -138,25 +138,21 @@ where
     }
 
     /// This function returns the complete signature tuple (R, u, v)
-    #[inline]
     pub fn complete_signature_tuple(&self) -> (&HomomorphicCommitment<P>, &K, &K) {
         (&self.public_nonce, &self.u, &self.v)
     }
 
     /// This function returns the first publicly known private key of the signature tuple (u)
-    #[inline]
     pub fn u(&self) -> &K {
         &self.u
     }
 
     /// This function returns the second publicly known private key of the signature tuple (v)
-    #[inline]
     pub fn v(&self) -> &K {
         &self.v
     }
 
     /// This function returns the public commitment public_nonce of the signature tuple (R)
-    #[inline]
     pub fn public_nonce(&self) -> &HomomorphicCommitment<P> {
         &self.public_nonce
     }

--- a/src/signatures/mod.rs
+++ b/src/signatures/mod.rs
@@ -4,8 +4,10 @@
 //! This module defines generic traits for handling the digital signature operations, agnostic
 //! of the underlying elliptic curve implementation
 
+mod commitment_and_public_key_signature;
 mod commitment_signature;
 mod schnorr;
 
+pub use commitment_and_public_key_signature::*;
 pub use commitment_signature::*;
 pub use schnorr::*;

--- a/src/wasm/key_utils.rs
+++ b/src/wasm/key_utils.rs
@@ -619,7 +619,7 @@ pub fn check_comandpubsig_signature(
 
     let sig = RistrettoComAndPubSig::new(ephemeral_commitment, ephemeral_pubkey, u_a, u_x, u_y);
     let msg = Blake256::digest(msg.as_bytes());
-    result.result = sig.verify_challenge(&commitment, &pubkey, msg.as_slice(), &factory);
+    result.result = sig.verify_challenge(&commitment, &pubkey, msg.as_slice(), &factory, &mut OsRng);
     JsValue::from_serde(&result).unwrap()
 }
 
@@ -1192,7 +1192,8 @@ mod test {
                 &commitment,
                 &pubkey,
                 &RistrettoSecretKey::from_bytes(&hash(SAMPLE_CHALLENGE)).unwrap(),
-                &PedersenCommitmentFactory::default()
+                &PedersenCommitmentFactory::default(),
+                &mut OsRng
             ));
         }
 

--- a/src/wasm/key_utils.rs
+++ b/src/wasm/key_utils.rs
@@ -394,26 +394,23 @@ pub fn check_comsig_signature(
 #[wasm_bindgen]
 pub fn sign_comandpubsig(private_key_a: &str, private_key_x: &str, private_key_y: &str, msg: &str) -> JsValue {
     let mut result = ComAndPubSignResult::default();
-    let a_key = match RistrettoSecretKey::from_hex(private_key_a) {
-        Ok(a_key) => a_key,
-        _ => {
-            result.error = "Invalid private key".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let a_key = if let Ok(a_key) = RistrettoSecretKey::from_hex(private_key_a) {
+        a_key
+    } else {
+        result.error = "Invalid private key".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
-    let x_key = match RistrettoSecretKey::from_hex(private_key_x) {
-        Ok(x_key) => x_key,
-        _ => {
-            result.error = "Invalid private key".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let x_key = if let Ok(x_key) = RistrettoSecretKey::from_hex(private_key_x) {
+        x_key
+    } else {
+        result.error = "Invalid private key".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
-    let y_key = match RistrettoSecretKey::from_hex(private_key_y) {
-        Ok(y_key) => y_key,
-        _ => {
-            result.error = "Invalid private key".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let y_key = if let Ok(y_key) = RistrettoSecretKey::from_hex(private_key_y) {
+        y_key
+    } else {
+        result.error = "Invalid private key".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
     sign_comandpubsig_message_with_key(&a_key, &x_key, &y_key, msg, None, None, None, &mut result);
     JsValue::from_serde(&result).unwrap()
@@ -433,55 +430,48 @@ pub fn sign_comandpubsig_challenge_with_nonce(
     challenge_as_hex: &str,
 ) -> JsValue {
     let mut result = ComAndPubSignResult::default();
-    let private_key_a = match RistrettoSecretKey::from_hex(private_key_a) {
-        Ok(private_key_a) => private_key_a,
-        _ => {
-            result.error = "Invalid private key_a".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let private_key_a = if let Ok(private_key_a) = RistrettoSecretKey::from_hex(private_key_a) {
+        private_key_a
+    } else {
+        result.error = "Invalid private key_a".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
-    let private_key_x = match RistrettoSecretKey::from_hex(private_key_x) {
-        Ok(private_key_x) => private_key_x,
-        _ => {
-            result.error = "Invalid private key_x".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let private_key_x = if let Ok(private_key_x) = RistrettoSecretKey::from_hex(private_key_x) {
+        private_key_x
+    } else {
+        result.error = "Invalid private key_x".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
-    let private_key_y = match RistrettoSecretKey::from_hex(private_key_y) {
-        Ok(private_key_y) => private_key_y,
-        _ => {
-            result.error = "Invalid private key_y".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let private_key_y = if let Ok(private_key_y) = RistrettoSecretKey::from_hex(private_key_y) {
+        private_key_y
+    } else {
+        result.error = "Invalid private key_y".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
-    let private_nonce_a = match RistrettoSecretKey::from_hex(private_nonce_a) {
-        Ok(private_nonce_a) => private_nonce_a,
-        _ => {
-            result.error = "Invalid private nonce_a".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let private_nonce_a = if let Ok(private_nonce_a) = RistrettoSecretKey::from_hex(private_nonce_a) {
+        private_nonce_a
+    } else {
+        result.error = "Invalid private nonce_a".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
-    let private_nonce_x = match RistrettoSecretKey::from_hex(private_nonce_x) {
-        Ok(private_nonce_x) => private_nonce_x,
-        _ => {
-            result.error = "Invalid private nonce_x".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let private_nonce_x = if let Ok(private_nonce_x) = RistrettoSecretKey::from_hex(private_nonce_x) {
+        private_nonce_x
+    } else {
+        result.error = "Invalid private nonce_x".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
-    let private_nonce_y = match RistrettoSecretKey::from_hex(private_nonce_y) {
-        Ok(private_nonce_y) => private_nonce_y,
-        _ => {
-            result.error = "Invalid private nonce_y".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let private_nonce_y = if let Ok(private_nonce_y) = RistrettoSecretKey::from_hex(private_nonce_y) {
+        private_nonce_y
+    } else {
+        result.error = "Invalid private nonce_y".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
 
-    let e = match from_hex(challenge_as_hex) {
-        Ok(e) => e,
-        _ => {
-            result.error = "Challenge was not valid HEX".to_string();
-            return JsValue::from_serde(&result).unwrap();
-        },
+    let e = if let Ok(e) = from_hex(challenge_as_hex) {
+        e
+    } else {
+        result.error = "Challenge was not valid HEX".to_string();
+        return JsValue::from_serde(&result).unwrap();
     };
     sign_comandpubsig_with_key(
         &private_key_a,


### PR DESCRIPTION
Commitment signatures are currently used (via the `CommitmentSignature` type) in Tari protocols as part of transaction authorization, as described in [RFC-0201](https://rfc.tari.com/RFC-0201_TariScript.html). The cryptographic design of commitment signatures is such that they are a representation proof of a Pedersen commitment that is bound to arbitrary message data (via a Fiat-Shamir challenge) to produce a signature.

In both cases where commitment signatures are used, two elements of input data are summed prior to generating or verifying the signature. The cases are:
- an output commitment and a sender offset public key
- an input commitment and a script public key
In both cases, the individual elements are included separately in the challenge.

This approach is not a proof of knowledge of the openings of the individual elements. Instead, it is a proof of knowledge of the commitment value, and of the sum of the commitment mask and discrete logarithm of the public key. It is unclear if this can lead to practical transaction malleability or other insecure outcomes.

This PR adds a new `CommitmentAndPublicKeySignature` signature type that mitigates the issue by proving knowledge of the commitment value, commitment mask, and public key discrete logarithm. As before, it is the responsibility of the caller to ensure that the Fiat-Shamir challenge is generated correctly.

The existing `CommitmentSignature` is left unchanged, but should not be used for the aforementioned use cases.