### PR TITLE
feat: port dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,26 +11,26 @@ version = "0.15.5"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.5" }
+tari_utilities = { git = "https://github.com/SWvheerden/tari_utilities.git", rev="a289ef90bb60d23b8175a028ae37df647142d14e" }
 
 base64 = "0.10.1"
 blake2 = "0.9.1"
-bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", tag = "v4.2.1" }
-bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", tag = "v0.0.6" }
-curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["serde", "alloc"] }
+bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", rev = "a9828c7586ffa113d8a2c287bbe1033d152267ca" }
+bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", rev = "d7563404ca7bc6b47f2c5122a6c84667fe7daf05" }
+curve25519-dalek = { package = "curve25519-dalek", version = "3.2.1", default-features = false, features = ["serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }
 lazy_static = "1.3.0"
 log = "0.4.0"
-merlin = { version = "3.0.0", default-features = false }
+merlin = { version = "2.0.1", default-features = false }
 once_cell = "1.8.0"
-rand = { version = "0.8.0", default-features = false }
+rand = { version = "0.7.0", default-features = false }
 serde = "1.0.89"
 serde_json = "1.0"
 sha3 = "0.9.0"
 thiserror = "1.0.20"
 wasm-bindgen = { version = "^0.2", features = ["serde-serialize"], optional = true }
-zeroize = "1.4.0"
+zeroize = "1.3.0"
 
 [dev-dependencies]
 bincode = "1.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = "1.3.0"
 log = "0.4.0"
 merlin = { version = "2.0.1", default-features = false }
 once_cell = "1.8.0"
-rand = { version = "0.7.0", default-features = false }
+rand = { version = "0.7.3", default-features = false, features = ["wasm-bindgen", "stdweb"] }
 serde = "1.0.89"
 serde_json = "1.0"
 sha3 = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["cryptography"]
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.15.5"
+version = "0.16.0"
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ version = "0.16.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/SWvheerden/tari_utilities.git", rev="a289ef90bb60d23b8175a028ae37df647142d14e" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
 
 base64 = "0.10.1"
 blake2 = "0.9.1"
-bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", rev = "a9828c7586ffa113d8a2c287bbe1033d152267ca" }
-bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", rev = "d7563404ca7bc6b47f2c5122a6c84667fe7daf05" }
+bulletproofs = { package = "tari_bulletproofs", git = "https://github.com/tari-project/bulletproofs", tag = "v4.3.0" }
+bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", tag = "v0.1.0" }
 curve25519-dalek = { package = "curve25519-dalek", version = "3.2.1", default-features = false, features = ["serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }

--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -22,7 +22,7 @@ fn setup(n: usize) -> (DalekRangeProofService, RistrettoSecretKey, u64, Pedersen
     let prover = DalekRangeProofService::new(n, &base).unwrap();
     let k = RistrettoSecretKey::random(&mut rng);
     let n_max = 1u64 << (n as u64 - 1);
-    let v = rng.gen_range(1..n_max);
+    let v = rng.gen_range(1, n_max);
     let c = base.commit_value(&k, v);
     (prover, k, v, c)
 }

--- a/src/ristretto/bulletproofs_plus.rs
+++ b/src/ristretto/bulletproofs_plus.rs
@@ -644,7 +644,7 @@ mod test {
                     let mut statements = vec![];
                     let mut extended_witnesses = vec![];
                     for m in 0..aggregation_size {
-                        let value = rng.gen_range(value_min..value_max);
+                        let value = rng.gen_range(value_min,value_max);
                         let minimum_value_promise = if m == 0 { value / 3 } else { 0 };
                         let secrets =
                             vec![RistrettoSecretKey(Scalar::random_not_zero(&mut rng)); extension_degree as usize];
@@ -770,7 +770,7 @@ mod test {
         provers_bulletproofs_plus_service.custom_transcript_label("123 range proof");
 
         // 2. Create witness data
-        let value = rng.gen_range(value_min..value_max);
+        let value = rng.gen_range(value_min,value_max);
         let minimum_value_promise = value / 3;
         let secrets = vec![RistrettoSecretKey(Scalar::random_not_zero(&mut rng)); extension_degree as usize];
         let extended_mask = RistrettoExtendedMask::assign(extension_degree, secrets.clone()).unwrap();
@@ -877,7 +877,7 @@ mod test {
         provers_bulletproofs_plus_service.custom_transcript_label("123 range proof");
 
         // 2. Create witness data
-        let value = rng.gen_range(value_min..value_max);
+        let value = rng.gen_range(value_min,value_max);
         let mask = RistrettoSecretKey(Scalar::random_not_zero(&mut rng));
         let commitment = factory.commit_value(&mask, value);
 

--- a/src/ristretto/bulletproofs_plus.rs
+++ b/src/ristretto/bulletproofs_plus.rs
@@ -644,7 +644,7 @@ mod test {
                     let mut statements = vec![];
                     let mut extended_witnesses = vec![];
                     for m in 0..aggregation_size {
-                        let value = rng.gen_range(value_min,value_max);
+                        let value = rng.gen_range(value_min, value_max);
                         let minimum_value_promise = if m == 0 { value / 3 } else { 0 };
                         let secrets =
                             vec![RistrettoSecretKey(Scalar::random_not_zero(&mut rng)); extension_degree as usize];
@@ -770,7 +770,7 @@ mod test {
         provers_bulletproofs_plus_service.custom_transcript_label("123 range proof");
 
         // 2. Create witness data
-        let value = rng.gen_range(value_min,value_max);
+        let value = rng.gen_range(value_min, value_max);
         let minimum_value_promise = value / 3;
         let secrets = vec![RistrettoSecretKey(Scalar::random_not_zero(&mut rng)); extension_degree as usize];
         let extended_mask = RistrettoExtendedMask::assign(extension_degree, secrets.clone()).unwrap();
@@ -877,7 +877,7 @@ mod test {
         provers_bulletproofs_plus_service.custom_transcript_label("123 range proof");
 
         // 2. Create witness data
-        let value = rng.gen_range(value_min,value_max);
+        let value = rng.gen_range(value_min, value_max);
         let mask = RistrettoSecretKey(Scalar::random_not_zero(&mut rng));
         let commitment = factory.commit_value(&mask, value);
 


### PR DESCRIPTION
Move away for `curve25519-dalek-ng` and rather use `curve25519-dalek` as this is the more updated repo.
Updated the version as this is a breaking change with respect to dependencies.
Matched the version of `rand` to `rand_core` so that the traits can work.