### PR TITLE
fix: include wasm features only if required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = "1.3.0"
 log = "0.4.0"
 merlin = { version = "2.0.1", default-features = false }
 once_cell = "1.8.0"
-rand = { version = "0.7.3", default-features = false, features = ["wasm-bindgen", "stdweb"] }
+rand = { version = "0.7.3", default-features = false }
 serde = "1.0.89"
 serde_json = "1.0"
 sha3 = "0.9.0"
@@ -45,7 +45,7 @@ cbindgen = "0.17.0"
 default = ["u64_backend"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 simd_backend = ["curve25519-dalek/simd_backend", "bulletproofs/simd_backend"]
-wasm = ["wasm-bindgen", "getrandom/js"]
+wasm = ["wasm-bindgen", "getrandom/js", "rand/wasm-bindgen"]
 ffi = []
 musig = []
 


### PR DESCRIPTION
Only includes `rand/wasm-bindgen` when the `wasm` feature is active.
It's not clear why stdweb was added. Since some wasm targets include rust stdlib, or are no_std. If required, it should probably be behind another feature flag. EDIT: https://rustsec.org/advisories/RUSTSEC-2020-0056.html