### PR TITLE
feat: add `Zeroize` support to key types, and create new shared secret type

### DIFF
--- a/src/dhke.rs
+++ b/src/dhke.rs
@@ -1,0 +1,48 @@
+// Copyright 2022 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! The robotic innards of a Diffie-Hellman key exchange (DHKE) producing a shared secret.
+//! Even though the result of a DHKE is the same type as a public key, it is typically treated as a secret value.
+//! To make this work more safely, we ensure that a DHKE result is cleared after use (but beware of subsequent copies or moves).
+//! Because a DHKE shared secret is intended to be used in further key derivation, the only visibility into it is as a byte array; it's not possible to directly extract the underlying public key type, and you probably shouldn't clone the byte array without a very good reason.
+//! If you need the underlying public key itself, you probably should be using something else.
+
+use std::ops::Mul;
+
+use zeroize::Zeroize;
+
+use crate::keys::PublicKey;
+
+pub struct DiffieHellmanSharedSecret<P>(P)
+where P: Zeroize;
+
+impl<P> DiffieHellmanSharedSecret<P>
+where
+    P: PublicKey + Zeroize,
+    for<'a> &'a <P as PublicKey>::K: Mul<&'a P, Output = P>,
+{
+    /// Perform a Diffie-Hellman key exchange
+    pub fn new(sk: &P::K, pk: &P) -> Self {
+        Self(sk * pk)
+    }
+
+    /// Get the shared secret as a byte array
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl<P> Zeroize for DiffieHellmanSharedSecret<P> where P: Zeroize {
+    /// Zeroize the shared secret's underlying public key
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl<P> Drop for DiffieHellmanSharedSecret<P> where P: Zeroize {
+    /// Zeroize the shared secret when out of scope or otherwise dropped
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -11,6 +11,7 @@ use std::ops::Add;
 use rand::{CryptoRng, Rng};
 use serde::{de::DeserializeOwned, ser::Serialize};
 use tari_utilities::ByteArray;
+use zeroize::{Zeroize, Zeroizing};
 
 /// A trait specifying common behaviour for representing `SecretKey`s. Specific elliptic curve
 /// implementations need to implement this trait for them to be used in Tari.
@@ -70,9 +71,10 @@ pub trait PublicKey:
 }
 
 /// This trait provides a common mechanism to calculate a shared secret using the private and public key of two parties
-pub trait DiffieHellmanSharedSecret: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default {
+pub trait DiffieHellmanSharedSecret: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default + Zeroize {
     /// The type of public key
     type PK: PublicKey;
     /// Generate a shared secret from one party's private key and another party's public key
-    fn shared_secret(k: &<Self::PK as PublicKey>::K, pk: &Self::PK) -> Self::PK;
+    fn shared_secret(k: &<Self::PK as PublicKey>::K, pk: &Self::PK) -> Zeroizing<Self::PK>
+        where <Self as DiffieHellmanSharedSecret>::PK:Zeroize;
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -11,7 +11,6 @@ use std::ops::Add;
 use rand::{CryptoRng, Rng};
 use serde::{de::DeserializeOwned, ser::Serialize};
 use tari_utilities::ByteArray;
-use zeroize::{Zeroize, Zeroizing};
 
 /// A trait specifying common behaviour for representing `SecretKey`s. Specific elliptic curve
 /// implementations need to implement this trait for them to be used in Tari.
@@ -68,13 +67,4 @@ pub trait PublicKey:
         let pk = Self::from_secret_key(&k);
         (k, pk)
     }
-}
-
-/// This trait provides a common mechanism to calculate a shared secret using the private and public key of two parties
-pub trait DiffieHellmanSharedSecret: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default + Zeroize {
-    /// The type of public key
-    type PK: PublicKey;
-    /// Generate a shared secret from one party's private key and another party's public key
-    fn shared_secret(k: &<Self::PK as PublicKey>::K, pk: &Self::PK) -> Zeroizing<Self::PK>
-        where <Self as DiffieHellmanSharedSecret>::PK:Zeroize;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate lazy_static;
 #[macro_use]
 mod macros;
 pub mod commitment;
+pub mod dhke;
 pub mod hash;
 pub mod hashing;
 pub mod keys;

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -21,7 +21,7 @@ use digest::Digest;
 use once_cell::sync::OnceCell;
 use rand::{CryptoRng, Rng};
 use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, Hashable};
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
     errors::HashingError,
@@ -340,8 +340,8 @@ impl DiffieHellmanSharedSecret for RistrettoPublicKey {
     type PK = RistrettoPublicKey;
 
     /// Generate a shared secret from one party's private key and another party's public key
-    fn shared_secret(k: &<Self::PK as PublicKey>::K, pk: &Self::PK) -> Self::PK {
-        k * pk
+    fn shared_secret(k: &<Self::PK as PublicKey>::K, pk: &Self::PK) -> Zeroizing<Self::PK> {
+        Zeroizing::new(k * pk)
     }
 }
 

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -50,6 +50,7 @@ use crate::{
 /// let _k3 = RistrettoSecretKey::random(&mut rng);
 /// ```
 #[derive(Eq, Clone, Default, Zeroize)]
+#[zeroize(drop)]
 pub struct RistrettoSecretKey(pub(crate) Scalar);
 
 const SCALAR_LENGTH: usize = 32;
@@ -64,13 +65,6 @@ impl SecretKey for RistrettoSecretKey {
     /// Return a random secret key on the `ristretto255` curve using the supplied CSPRNG.
     fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         RistrettoSecretKey(Scalar::random(rng))
-    }
-}
-
-impl Drop for RistrettoSecretKey {
-    /// Clear the secret key value in memory when it goes out of scope
-    fn drop(&mut self) {
-        self.0.zeroize()
     }
 }
 

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -21,12 +21,12 @@ use digest::Digest;
 use once_cell::sync::OnceCell;
 use rand::{CryptoRng, Rng};
 use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, Hashable};
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroize;
 
 use crate::{
     errors::HashingError,
     hashing::{DerivedKeyDomain, DomainSeparatedHasher, DomainSeparation},
-    keys::{DiffieHellmanSharedSecret, PublicKey, SecretKey},
+    keys::{PublicKey, SecretKey},
 };
 
 /// The [SecretKey](trait.SecretKey.html) implementation for [Ristretto](https://ristretto.group) is a thin wrapper
@@ -333,15 +333,6 @@ impl PublicKey for RistrettoPublicKey {
         let s: Vec<&Scalar> = scalars.iter().map(|k| &k.0).collect();
         let p = RistrettoPoint::multiscalar_mul(s, p);
         RistrettoPublicKey::new_from_pk(p)
-    }
-}
-
-impl DiffieHellmanSharedSecret for RistrettoPublicKey {
-    type PK = RistrettoPublicKey;
-
-    /// Generate a shared secret from one party's private key and another party's public key
-    fn shared_secret(k: &<Self::PK as PublicKey>::K, pk: &Self::PK) -> Zeroizing<Self::PK> {
-        Zeroizing::new(k * pk)
     }
 }
 


### PR DESCRIPTION
Adds support for `Zeroize` to both the `RistrettoSecretKey` and `RistrettoPublicKey` types, and creates a new shared secret type. Adds a test for both key types.

This work adds derived `Zeroize` support to `RistrettoSecretKey` to support the use case where we want to clear a secret key in scope.

It also adds custom `Zeroize` support to `RistrettoPublicKey`. In this case, we zeroize both the underlying `RistrettoPoint` and the `CompressedRistrettoPoint` contained in a `OnceCell`. This is useful in the case where a `RistrettoPublicKey` represents secret data, like in the case of a Diffie-Hellman shared secret. Note that we do not zeroize on drop, so this use case must be handled manually, ideally through the use of a `Zeroizing` wrapper.

Finally, it adds a new generic `DiffieHellmanSharedSecret<P>` type for `P: Zeroize`. This type zeroizes on drop. It does not provide direct access to the underlying public key, but only gives an `as_bytes` array view. This removes the need for `zeroize` support by implementations, and provides safer use of shared secrets.