### PR TITLE
feat!: improve signature api 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["cryptography"]
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.15.7"
+version = "0.16.0"
 edition = "2018"
 
 [dependencies]

--- a/benches/signatures.rs
+++ b/benches/signatures.rs
@@ -47,7 +47,7 @@ fn sign_message(c: &mut Criterion) {
         b.iter_batched(
             gen_keypair,
             |d| {
-                let _sig = RistrettoSchnorr::sign_message(d.k, d.m.to_vec()).unwrap();
+                let _sig = RistrettoSchnorr::sign_message(&d.k, d.m.to_vec()).unwrap();
             },
             BatchSize::SmallInput,
         );
@@ -61,7 +61,7 @@ fn verify_message(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let d = gen_keypair();
-                let s = RistrettoSchnorr::sign_message(d.k.clone(), d.m.to_vec()).unwrap();
+                let s = RistrettoSchnorr::sign_message(&d.k, d.m.to_vec()).unwrap();
                 (d, s)
             },
             |(d, s)| assert!(s.verify_message(&d.p, d.m.as_bytes())),

--- a/benches/signatures.rs
+++ b/benches/signatures.rs
@@ -9,7 +9,6 @@ use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
 };
-use tari_utilities::byte_array::ByteArray;
 
 fn generate_secret_key(c: &mut Criterion) {
     c.bench_function("Generate secret key", |b| {
@@ -46,7 +45,7 @@ fn sign_message(c: &mut Criterion) {
         b.iter_batched(
             gen_keypair,
             |d| {
-                let _sig = RistrettoSchnorr::sign_message(&d.k, &d.m).unwrap();
+                let _sig = RistrettoSchnorr::sign_message(&d.k, d.m).unwrap();
             },
             BatchSize::SmallInput,
         );
@@ -60,10 +59,10 @@ fn verify_message(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let d = gen_keypair();
-                let s = RistrettoSchnorr::sign_message(&d.k, &d.m).unwrap();
+                let s = RistrettoSchnorr::sign_message(&d.k, d.m).unwrap();
                 (d, s)
             },
-            |(d, s)| assert!(s.verify_message(&d.p, &d.m)),
+            |(d, s)| assert!(s.verify_message(&d.p, d.m)),
             BatchSize::SmallInput,
         );
     });

--- a/src/ffi/keys.rs
+++ b/src/ffi/keys.rs
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn sign(
         _ => return STR_CONV_ERR,
     };
     let e = SchnorrSignature::construct_domain_separated_challenge::<_, Blake256>(&pub_r, &pubkey, msg.as_bytes());
-    let sig = match RistrettoSchnorr::sign_raw(k, r, e.as_ref()) {
+    let sig = match RistrettoSchnorr::sign_raw(&k, r, e.as_ref()) {
         Ok(sig) => sig,
         _ => return SIGNING_ERROR,
     };

--- a/src/ffi/keys.rs
+++ b/src/ffi/keys.rs
@@ -491,36 +491,30 @@ mod test {
             assert!(!verify(
                 null_mut(),
                 msg.as_ptr() as *const c_char,
-                &mut pub_nonce,
-                &mut signature,
+                &pub_nonce,
+                &signature,
                 &mut err_code
             ),);
+            assert!(!verify(&pub_key, null_mut(), &pub_nonce, &signature, &mut err_code),);
             assert!(!verify(
                 &pub_key,
+                msg.as_ptr() as *const c_char,
                 null_mut(),
-                &mut pub_nonce,
-                &mut signature,
+                &signature,
                 &mut err_code
             ),);
             assert!(!verify(
                 &pub_key,
                 msg.as_ptr() as *const c_char,
-                null_mut(),
-                &mut signature,
-                &mut err_code
-            ),);
-            assert!(!verify(
-                &pub_key,
-                msg.as_ptr() as *const c_char,
-                &mut pub_nonce,
+                &pub_nonce,
                 null_mut(),
                 &mut err_code
             ),);
             assert!(!verify(
                 &pub_key,
                 msg.as_ptr() as *const c_char,
-                &mut pub_nonce,
-                &mut signature,
+                &pub_nonce,
+                &signature,
                 null_mut()
             ),);
         }
@@ -540,8 +534,8 @@ mod test {
             assert!(verify(
                 &pub_key,
                 msg.as_ptr() as *const c_char,
-                &mut pub_nonce,
-                &mut signature,
+                &pub_nonce,
+                &signature,
                 &mut err_code
             ));
         }

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -520,6 +520,7 @@ pub trait DerivedKeyDomain: DomainSeparation {
 #[macro_export]
 macro_rules! hash_domain {
     ($name:ident, $domain:expr, $version: expr) => {
+        /// A hashing domain instance
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct $name;
 

--- a/src/ristretto/mod.rs
+++ b/src/ristretto/mod.rs
@@ -21,7 +21,7 @@ pub use self::{
     ristretto_com_and_pub_sig::RistrettoComAndPubSig,
     ristretto_com_sig::RistrettoComSig,
     ristretto_keys::{RistrettoPublicKey, RistrettoSecretKey},
-    ristretto_sig::RistrettoSchnorr,
+    ristretto_sig::{RistrettoSchnorr, RistrettoSchnorrWithDomain},
 };
 
 // test modules

--- a/src/ristretto/ristretto_sig.rs
+++ b/src/ristretto/ristretto_sig.rs
@@ -192,7 +192,7 @@ mod test {
         assert_ne!(hash.as_ref(), naiive.as_bytes());
         assert_eq!(
             to_hex(hash.as_ref()),
-            "e64d66b31e2b1c81272f5574f41ab2c997114436c2d3706dca1cf947bed60198"
+            "d8f6b29b641113c91175b8d44f265ff1167d58d5aa5ee03e6f1f521505b09d80"
         );
     }
 

--- a/src/ristretto/ristretto_sig.rs
+++ b/src/ristretto/ristretto_sig.rs
@@ -223,6 +223,8 @@ mod test {
         // assert_ne!(sig1, sig2);
         // Prove that the nonces were reused. Again, NEVER do this
         assert_eq!(sig1.get_public_nonce(), sig2.get_public_nonce());
+        assert!(sig1.verify_message(&P, msg));
+        assert!(sig2.verify_message(&P, msg));
         // But the signatures are different, for the same message, secret and nonce.
         assert_ne!(sig1.get_signature(), sig2.get_signature());
     }

--- a/src/ristretto/ristretto_sig.rs
+++ b/src/ristretto/ristretto_sig.rs
@@ -54,7 +54,7 @@ use crate::{
 /// #[allow(non_snake_case)]
 /// let (k, P) = get_keypair();
 /// let msg = "Small Gods";
-/// let sig = RistrettoSchnorr::sign_message(k, &msg);
+/// let sig = RistrettoSchnorr::sign_message(&k, &msg);
 /// ```
 ///
 /// # Verifying signatures
@@ -79,7 +79,7 @@ use crate::{
 /// # #[allow(non_snake_case)]
 /// let P = RistrettoPublicKey::from_secret_key(&k);
 /// let sig: SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey> =
-///     SchnorrSignature::sign_message(k, msg).unwrap();
+///     SchnorrSignature::sign_message(&k, msg).unwrap();
 /// assert!(sig.verify_message(&P, msg));
 /// ```
 pub type RistrettoSchnorr = SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey>;
@@ -121,7 +121,7 @@ mod test {
             .finalize();
         let e_key = RistrettoSecretKey::from_bytes(&e).unwrap();
         let s = &r + &e_key * &k;
-        let sig = RistrettoSchnorr::sign_raw(k, r, &e).unwrap();
+        let sig = RistrettoSchnorr::sign_raw(&k, r, &e).unwrap();
         let R_calc = sig.get_public_nonce();
         assert_eq!(R, *R_calc);
         assert_eq!(sig.get_signature(), &s);
@@ -153,9 +153,9 @@ mod test {
             .chain(b"Moving Pictures")
             .finalize();
         // Calculate Alice's signature
-        let s1 = RistrettoSchnorr::sign_raw(k1, r1, &e).unwrap();
+        let s1 = RistrettoSchnorr::sign_raw(&k1, r1, &e).unwrap();
         // Calculate Bob's signature
-        let s2 = RistrettoSchnorr::sign_raw(k2, r2, &e).unwrap();
+        let s2 = RistrettoSchnorr::sign_raw(&k2, r2, &e).unwrap();
         // Now add the two signatures together
         let s_agg = &s1 + &s2;
         // Check that the multi-sig verifies
@@ -171,7 +171,7 @@ mod test {
         let m = from_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
         let k = RistrettoSecretKey::random(&mut rng);
         let r = RistrettoSecretKey::random(&mut rng);
-        assert!(RistrettoSchnorr::sign_raw(k, r, &m).is_ok());
+        assert!(RistrettoSchnorr::sign_raw(&k, r, &m).is_ok());
     }
 
     #[test]
@@ -201,7 +201,7 @@ mod test {
     fn sign_and_verify_message() {
         let mut rng = rand::thread_rng();
         let (k, P) = RistrettoPublicKey::random_keypair(&mut rng);
-        let sig = RistrettoSchnorr::sign_message(k, "Queues are things that happen to other people").unwrap();
+        let sig = RistrettoSchnorr::sign_message(&k, "Queues are things that happen to other people").unwrap();
         assert!(sig.verify_message(&P, "Queues are things that happen to other people"));
         assert!(!sig.verify_message(&P, "Qs are things that happen to other people"));
         assert!(!sig.verify_message(&(&P + &P), "Queues are things that happen to other people"));

--- a/src/ristretto/ristretto_sig.rs
+++ b/src/ristretto/ristretto_sig.rs
@@ -83,6 +83,36 @@ use crate::{
 /// assert!(sig.verify_message(&P, msg));
 /// ```
 pub type RistrettoSchnorr = SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey, SchnorrSigChallenge>;
+
+/// # A Schnorr signature implementation on Ristretto with a custom domain separation tag
+///
+/// Usage is identical to [`RistrettoSchnorr`], except that you are able to specify the domain separation tag to use
+/// when computing challenges for the signature.
+///
+/// ## Example
+/// /// ```edition2018
+/// # use tari_crypto::ristretto::*;
+/// # use tari_crypto::keys::*;
+/// # use tari_crypto::hash_domain;
+/// # use tari_crypto::signatures::SchnorrSignature;
+/// # use tari_crypto::hash::blake2::Blake256;
+/// # use tari_utilities::hex::*;
+/// # use tari_utilities::ByteArray;
+/// # use digest::Digest;
+///
+/// hash_domain!(MyCustomDomain, "com.example.custom");
+///
+/// let msg = "Maskerade";
+/// let k = RistrettoSecretKey::from_hex(
+///     "bd0b253a619310340a4fa2de54cdd212eac7d088ee1dc47e305c3f6cbd020908",
+/// )
+/// .unwrap();
+/// # #[allow(non_snake_case)]
+/// let P = RistrettoPublicKey::from_secret_key(&k);
+/// let sig: SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey, MyCustomDomain> =
+///     SchnorrSignature::sign_message(&k, msg).unwrap();
+/// assert!(sig.verify_message(&P, msg));
+/// ```
 pub type RistrettoSchnorrWithDomain<H> = SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey, H>;
 
 #[cfg(test)]

--- a/src/ristretto/utils.rs
+++ b/src/ristretto/utils.rs
@@ -45,7 +45,7 @@ pub fn sign<D: Digest>(
         .finalize()
         .to_vec();
     let e = RistrettoSecretKey::from_bytes(&message).map_err(|_| SchnorrSignatureError::InvalidChallenge)?;
-    let s = RistrettoSchnorr::sign_raw(&private_key, nonce.clone(), e.as_bytes())?;
+    let s = RistrettoSchnorr::sign_raw(private_key, nonce.clone(), e.as_bytes())?;
     Ok(SignatureSet {
         nonce,
         public_nonce,

--- a/src/ristretto/utils.rs
+++ b/src/ristretto/utils.rs
@@ -45,7 +45,7 @@ pub fn sign<D: Digest>(
         .finalize()
         .to_vec();
     let e = RistrettoSecretKey::from_bytes(&message).map_err(|_| SchnorrSignatureError::InvalidChallenge)?;
-    let s = RistrettoSchnorr::sign_raw(private_key.clone(), nonce.clone(), e.as_bytes())?;
+    let s = RistrettoSchnorr::sign_raw(&private_key, nonce.clone(), e.as_bytes())?;
     Ok(SignatureSet {
         nonce,
         public_nonce,

--- a/src/ristretto/utils.rs
+++ b/src/ristretto/utils.rs
@@ -29,6 +29,10 @@ pub struct SignatureSet {
 /// # Panics
 ///
 /// The function panics if it cannot generate a suitable signature
+#[deprecated(
+    since = "0.16.0",
+    note = "Use SchnorrSignature::sign_message instead. This method will be removed in v1.0.0"
+)]
 pub fn sign<D: Digest>(
     private_key: &RistrettoSecretKey,
     message: &[u8],
@@ -41,7 +45,7 @@ pub fn sign<D: Digest>(
         .finalize()
         .to_vec();
     let e = RistrettoSecretKey::from_bytes(&message).map_err(|_| SchnorrSignatureError::InvalidChallenge)?;
-    let s = RistrettoSchnorr::sign(private_key.clone(), nonce.clone(), e.as_bytes())?;
+    let s = RistrettoSchnorr::sign_raw(private_key.clone(), nonce.clone(), e.as_bytes())?;
     Ok(SignatureSet {
         nonce,
         public_nonce,

--- a/src/signatures/schnorr.rs
+++ b/src/signatures/schnorr.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 // Define the hashing domain for Schnorr signatures
-hash_domain!(SchnorrSigChallenge, "SchnorrSignature", 1);
+hash_domain!(SchnorrSigChallenge, "com.tari.schnorr_signature", 1);
 
 /// An error occurred during construction of a SchnorrSignature
 #[derive(Clone, Debug, Error, PartialEq, Eq, Deserialize, Serialize)]
@@ -264,5 +264,19 @@ where
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{hashing::DomainSeparation, signatures::SchnorrSigChallenge};
+
+    #[test]
+    fn schnorr_hash_domain() {
+        assert_eq!(SchnorrSigChallenge::domain(), "com.tari.schnorr_signature");
+        assert_eq!(
+            SchnorrSigChallenge::domain_separation_tag("test"),
+            "com.tari.schnorr_signature.v1.test"
+        );
     }
 }

--- a/src/signatures/schnorr.rs
+++ b/src/signatures/schnorr.rs
@@ -79,8 +79,11 @@ where
                 instead, depending on your use case. This function will be removed in v1.0.0"
     )]
     pub fn sign(secret: K, nonce: K, challenge: &[u8]) -> Result<Self, SchnorrSignatureError>
-    where K: Add<Output = K> + Mul<P, Output = P> + Mul<Output = K> {
-        Self::sign_raw(secret, nonce, challenge)
+    where
+        K: Add<Output = K>,
+        for<'a> K: Mul<&'a K, Output = K>,
+    {
+        Self::sign_raw(&secret, nonce, challenge)
     }
 
     /// Sign a challenge with the given `secret` and private `nonce`. Returns an SchnorrSignatureError if `<K as
@@ -90,8 +93,8 @@ where
     /// been constructed such that all commitments are already included in the challenge.
     ///
     /// If you want a simple API that binds the nonce and public key to the message, use [`sign_message`] instead.
-    pub fn sign_raw(secret: K, nonce: K, challenge: &[u8]) -> Result<Self, SchnorrSignatureError>
-    where K: Add<Output = K> + Mul<P, Output = P> + Mul<Output = K> {
+    pub fn sign_raw<'a>(secret: &'a K, nonce: K, challenge: &[u8]) -> Result<Self, SchnorrSignatureError>
+    where K: Add<Output = K> + Mul<&'a K, Output = K> {
         // s = r + e.k
         let e = match K::from_bytes(challenge) {
             Ok(e) => e,
@@ -110,9 +113,9 @@ where
     ///
     /// it is possible to customise the challenge by using [`construct_domain_separated_challenge`] and [`sign_raw`]
     /// yourself, or even use [`sign_raw`] using a completely custom challenge.
-    pub fn sign_message<B>(secret: K, message: B) -> Result<Self, SchnorrSignatureError>
+    pub fn sign_message<'a, B>(secret: &'a K, message: B) -> Result<Self, SchnorrSignatureError>
     where
-        K: Add<Output = K> + Mul<P, Output = P> + Mul<Output = K>,
+        K: Add<Output = K> + Mul<&'a K, Output = K>,
         B: AsRef<[u8]>,
     {
         let nonce = K::random(&mut rand::thread_rng());

--- a/src/signatures/schnorr.rs
+++ b/src/signatures/schnorr.rs
@@ -78,6 +78,7 @@ where
         note = "This method probably doesn't do what you think it does. Please use `sign_message` or `sign_raw` \
                 instead, depending on your use case. This function will be removed in v1.0.0"
     )]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn sign(secret: K, nonce: K, challenge: &[u8]) -> Result<Self, SchnorrSignatureError>
     where
         K: Add<Output = K>,
@@ -120,7 +121,7 @@ where
     {
         let nonce = K::random(&mut rand::thread_rng());
         let public_nonce = P::from_secret_key(&nonce);
-        let public_key = P::from_secret_key(&secret);
+        let public_key = P::from_secret_key(secret);
         let challenge = Self::construct_domain_separated_challenge::<_, Blake256>(&public_nonce, &public_key, message);
         Self::sign_raw(secret, nonce, challenge.as_ref())
     }

--- a/src/wasm/key_utils.rs
+++ b/src/wasm/key_utils.rs
@@ -149,7 +149,7 @@ pub fn sign_challenge_with_nonce(private_key: &str, private_nonce: &str, challen
         },
     };
 
-    let sig = match RistrettoSchnorr::sign_raw(k, r, &e) {
+    let sig = match RistrettoSchnorr::sign_raw(&k, r, &e) {
         Ok(s) => s,
         Err(e) => {
             result.error = format!("Could not create signature. {e}");
@@ -183,7 +183,7 @@ pub(super) fn sign_with_key(
     };
     let P = RistrettoPublicKey::from_secret_key(k);
     let e = SchnorrSignature::construct_domain_separated_challenge::<_, Blake256>(&R, &P, msg);
-    let sig = match RistrettoSchnorr::sign_raw(k.clone(), r, e.as_ref()) {
+    let sig = match RistrettoSchnorr::sign_raw(&k, r, e.as_ref()) {
         Ok(s) => s,
         Err(e) => {
             result.error = format!("Could not create signature. {e}");
@@ -739,7 +739,7 @@ mod test {
 
     fn create_signature(msg: &str) -> (RistrettoSchnorr, RistrettoPublicKey, RistrettoSecretKey) {
         let (sk, pk) = random_keypair();
-        let sig = SchnorrSignature::sign_message(sk.clone(), msg.as_bytes()).unwrap();
+        let sig = SchnorrSignature::sign_message(&sk, msg.as_bytes()).unwrap();
         (sig, pk, sk)
     }
 

--- a/src/wasm/key_utils.rs
+++ b/src/wasm/key_utils.rs
@@ -23,7 +23,6 @@ use crate::{
         RistrettoSchnorr,
         RistrettoSecretKey,
     },
-    signatures::SchnorrSignature,
 };
 
 /// Result of calling [check_signature] and [check_comsig_signature] and [check_comandpubsig_signature]
@@ -182,7 +181,7 @@ pub(super) fn sign_with_key(
         None => RistrettoPublicKey::random_keypair(&mut OsRng),
     };
     let P = RistrettoPublicKey::from_secret_key(k);
-    let e = SchnorrSignature::construct_domain_separated_challenge::<_, Blake256>(&R, &P, msg);
+    let e = RistrettoSchnorr::construct_domain_separated_challenge::<_, Blake256>(&R, &P, msg);
     let sig = match RistrettoSchnorr::sign_raw(k, r, e.as_ref()) {
         Ok(s) => s,
         Err(e) => {
@@ -850,7 +849,7 @@ mod test {
             assert!(result.error.is_empty());
             let p_nonce = RistrettoPublicKey::from_hex(&result.public_nonce.unwrap()).unwrap();
             let s = RistrettoSecretKey::from_hex(&result.signature.unwrap()).unwrap();
-            assert!(SchnorrSignature::new(p_nonce, s).verify_message(&pk, SAMPLE_CHALLENGE));
+            assert!(RistrettoSchnorr::new(p_nonce, s).verify_message(&pk, SAMPLE_CHALLENGE));
         }
 
         #[wasm_bindgen_test]
@@ -902,7 +901,7 @@ mod test {
             let p_nonce = RistrettoPublicKey::from_hex(&result.public_nonce.unwrap()).unwrap();
             assert_eq!(p_nonce, expected_pr);
             let s = RistrettoSecretKey::from_hex(&result.signature.unwrap()).unwrap();
-            assert!(SchnorrSignature::new(p_nonce, s).verify_challenge(&pk, &hash(SAMPLE_CHALLENGE)));
+            assert!(RistrettoSchnorr::new(p_nonce, s).verify_challenge(&pk, &hash(SAMPLE_CHALLENGE)));
         }
     }
 

--- a/src/wasm/key_utils.rs
+++ b/src/wasm/key_utils.rs
@@ -183,7 +183,7 @@ pub(super) fn sign_with_key(
     };
     let P = RistrettoPublicKey::from_secret_key(k);
     let e = SchnorrSignature::construct_domain_separated_challenge::<_, Blake256>(&R, &P, msg);
-    let sig = match RistrettoSchnorr::sign_raw(&k, r, e.as_ref()) {
+    let sig = match RistrettoSchnorr::sign_raw(k, r, e.as_ref()) {
         Ok(s) => s,
         Err(e) => {
             result.error = format!("Could not create signature. {e}");

--- a/src/wasm/keyring.rs
+++ b/src/wasm/keyring.rs
@@ -148,11 +148,10 @@ impl KeyRing {
 
 #[cfg(test)]
 mod test {
-    use blake2::{digest::Output, Digest};
     use wasm_bindgen_test::*;
 
     use super::*;
-    use crate::{hash::blake2::Blake256, keys::SecretKey, ristretto::RistrettoSchnorr};
+    use crate::{keys::SecretKey, ristretto::RistrettoSchnorr};
 
     const SAMPLE_CHALLENGE: &str = "გამარჯობა";
 
@@ -161,10 +160,6 @@ mod test {
         kr.new_key("a".into());
         kr.new_key("b".into());
         kr
-    }
-
-    fn hash<T: AsRef<[u8]>>(preimage: T) -> Output<Blake256> {
-        Blake256::digest(preimage.as_ref())
     }
 
     fn create_commitment(k: &RistrettoSecretKey, v: u64) -> PedersenCommitment {
@@ -240,7 +235,7 @@ mod test {
             let kr = new_keyring();
             let sig = sign(&kr, "a").unwrap();
             let pk = kr.expect_public_key("a");
-            assert!(sig.verify_challenge(pk, &hash(SAMPLE_CHALLENGE)));
+            assert!(sig.verify_message(pk, SAMPLE_CHALLENGE));
         }
     }
 


### PR DESCRIPTION
There are some footguns in the `SchnorrSignature::sign` method that this
PR seeks to mitigate.

Firstly, it's not clear in the function docs that the nonce and pubkey
are assumed to have been bound by the caller in the challenge.

The docs are updated to make this clearer.

Secondly, we deprecate the sign method and the utility module's sign
method in favour of:

- `sign_raw`, which is identical to the current sign method, but with a
  name that conveys the risk associated with using it.
- `sign_message`, which does what many clients might have thought `sign`
  does, which correctly binds a nonce and public key to the message
being signed in the challenge construction.
- Matching `verify_*` methods.

Tests and docs have been updated to reflect the changes.

The WASM and FFI library now use the domain-separated hashing algorithm
to generate challenges for signatures.