### PR TITLE
Functionality to work with `Hidden` types

### DIFF
--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -31,7 +31,7 @@
 use std::{marker::PhantomData, ops::Deref};
 
 use blake2::VarBlake2b;
-use digest::{Digest, Output, Update};
+use digest::{Digest, Output, Update, FixedOutput};
 use sha3::Sha3_256;
 use tari_utilities::ByteArray;
 
@@ -306,6 +306,19 @@ pub trait AsFixedBytes<const I: usize>: AsRef<[u8]> {
 
 impl<const I: usize, D: Digest> AsFixedBytes<I> for DomainSeparatedHash<D> {}
 
+impl<TInnerDigest: FixedOutput, TDomain: DomainSeparation> FixedOutput for DomainSeparatedHasher<TInnerDigest, TDomain> {
+    type OutputSize = TInnerDigest::OutputSize;
+
+
+    fn finalize_into(self, out: &mut digest::generic_array::GenericArray<u8, Self::OutputSize>) {
+        self.inner.finalize_into(out);
+    }
+
+    fn finalize_into_reset(&mut self, out: &mut digest::generic_array::GenericArray<u8, Self::OutputSize>) {
+        self.inner.finalize_into_reset(out);
+    }
+}
+
 /// Implements Digest so that it can be used for other crates
 impl<TInnerDigest: Digest, TDomain: DomainSeparation> Digest for DomainSeparatedHasher<TInnerDigest, TDomain> {
     type OutputSize = TInnerDigest::OutputSize;
@@ -571,7 +584,7 @@ pub fn create_hasher<D: Digest, HD: DomainSeparation>() -> DomainSeparatedHasher
 #[cfg(test)]
 mod test {
     use blake2::Blake2b;
-    use digest::Digest;
+    use digest::{Digest, FixedOutput, generic_array::GenericArray};
     use tari_utilities::hex::{from_hex, to_hex};
 
     use crate::{
@@ -626,6 +639,26 @@ mod test {
         assert_eq!(MacDomain::domain(), "com.tari.mac");
         assert_eq!(MacDomain::domain_separation_tag(""), "com.tari.mac.v1");
         assert_eq!(MacDomain::domain_separation_tag("test"), "com.tari.mac.v1.test");
+    }
+
+    #[test]
+    fn finalize_into() {
+        hash_domain!(TestHasher, "com.example.test");
+        let mut hasher = DomainSeparatedHasher::<Blake256, TestHasher>::new();
+        hasher.update([0, 0, 0]);
+
+        let mut output = GenericArray::<u8, <Blake256 as Digest>::OutputSize>::default();
+        hasher.finalize_into(&mut output);
+    }
+
+    #[test]
+    fn finalize_into_reset() {
+        hash_domain!(TestHasher, "com.example.test");
+        let mut hasher = DomainSeparatedHasher::<Blake256, TestHasher>::new();
+        hasher.update([0, 0, 0]);
+
+        let mut output = GenericArray::<u8, <Blake256 as Digest>::OutputSize>::default();
+        hasher.finalize_into_reset(&mut output);
     }
 
     #[test]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -11,6 +11,7 @@ use std::ops::Add;
 use rand::{CryptoRng, Rng};
 use serde::{de::DeserializeOwned, ser::Serialize};
 use tari_utilities::ByteArray;
+use zeroize::Zeroize;
 
 /// A trait specifying common behaviour for representing `SecretKey`s. Specific elliptic curve
 /// implementations need to implement this trait for them to be used in Tari.
@@ -26,7 +27,7 @@ use tari_utilities::ByteArray;
 /// let k = RistrettoSecretKey::random(&mut rng);
 /// let p = RistrettoPublicKey::from_secret_key(&k);
 /// ```
-pub trait SecretKey: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default {
+pub trait SecretKey: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default + Zeroize {
     /// The length of the key, in bytes
     fn key_length() -> usize;
     /// Generates a random secret key
@@ -40,7 +41,7 @@ pub trait SecretKey: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + D
 ///
 /// See [SecretKey](trait.SecretKey.html) for an example.
 pub trait PublicKey:
-    ByteArray + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Serialize + DeserializeOwned
+    ByteArray + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Serialize + DeserializeOwned + Zeroize
 {
     /// The output size len of Public Key
     const KEY_LEN: usize;


### PR DESCRIPTION
Work in `tari_utilities` [PR 52](https://github.com/tari-project/tari_utilities/pull/52) provides a new `Hidden` type for hidden data that supports safer handling of underlying data that supports the `Zeroize` trait. This is intended to handle things like passphrases, seed words, and derived key materials.

Initial work by @jorgeantonio21 on migrating existing key derivation function (KDF) outputs to use `Hidden` found two issues pretty quickly:
- The generic `SecretKey` and `PublicKey` traits do not enforce `Zeroize`, even though the Ristretto-based implementation in this crate do.
- The hashing API keeps copies of hash output data in memory that is not zeroized.

The first issue is more of an annoyance, since it means a `Hidden` type containing a generic `SecretKey` or `PublicKey` needs to add additional `Zeroize` trait bounds everywhere. This PR adds the trait bound to both. Since `RistrettoSecretKey` and `RistrettoPublicKey` already implement `Zeroize`, this change is seamless. This addresses part of [issue 147](https://github.com/tari-project/tari-crypto/issues/147).

The second issue is trickier. While we can't control what goes on inside the state of any underlying hash function (e.g. `Blake256` in the `tari` crate), and while some hashing API use cases don't assume the output is sensitive, KDF use cases do. For these cases, we want to minimize non-zeroized copies of the output. This PR mitigates this by implementing `FixedOutput` for `DomainSeparatedHasher`, which adds in-place output support. The use of the required `finalize_into_reset` _might_ be helpful in this case, since it doesn't consume the hasher but resets its internal state (albeit in a way that isn't clear to me).