### PR TITLE
fix!: signature serialization

### DIFF
--- a/src/signatures/schnorr.rs
+++ b/src/signatures/schnorr.rs
@@ -45,6 +45,7 @@ pub enum SchnorrSignatureError {
 pub struct SchnorrSignature<P, K, H = SchnorrSigChallenge> {
     public_nonce: P,
     signature: K,
+    #[serde(skip)]
     _phantom: PhantomData<H>,
 }
 


### PR DESCRIPTION
The recent [update](https://github.com/tari-project/tari-crypto/pull/145) to the Schnorr signature API introduced a breaking serialization change due to the presence of a new `PhantomData` field that serializes to a null value, which breaks compatibility with existing signatures.

This work introduces a simple change that instructs `serde` to ignore the field during serialization and deserialization. There shouldn't be any other problems with deserialization, since `serde` will apply the correct default type.

BREAKING CHANGE: Technically this is a breaking change to serialization, even though it restores the expected serialization for proper compatibility with other crates.