### PR TITLE
feat: update `tari_utilities` and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.16.1"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.7" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag="v0.4.9" }
 
 base64 = "0.10.1"
 blake2 = "0.9.1"

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -663,6 +663,20 @@ mod test {
     }
 
     #[test]
+    fn test_safe_array() {
+        use tari_utilities::{hidden::Hidden, hidden_type, safe_array::SafeArray};
+        use zeroize::Zeroize;
+
+        hash_domain!(TestHasher, "com.example.test");
+        let mut hasher = DomainSeparatedHasher::<Blake256, TestHasher>::new();
+        hasher.update([0, 0, 0]);
+
+        hidden_type!(Key, SafeArray<u8, 32>);
+        let mut key = Key::from(SafeArray::default()); // all zeroes
+        hasher.finalize_into_reset(GenericArray::from_mut_slice(key.reveal_mut()));
+    }
+
+    #[test]
     fn dst_hasher() {
         hash_domain!(GenericHashDomain, "com.tari.generic");
         assert_eq!(GenericHashDomain::domain_separation_tag(""), "com.tari.generic.v1");


### PR DESCRIPTION
Updates the `tari_utilities` dependency to support the new hidden type API. Adds a test that the new `SafeArray` type plays nicely with the hashing API.

Supersedes [PR 151](https://github.com/tari-project/tari-crypto/pull/151).