### PR TITLE
fix: serialization of RistrettoSecretKey

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           command: test
           # TODO: re-add all features once https://github.com/rust-lang/packed_simd/pull/341 is used by dalek
           # args: --release --all-features
-          args: --release --features wasm --features ffi
+          args: --release --features wasm --features ffi --features borsh
       - name: docs build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Fix serialization of the RistrettoSecretKey.
It was expecting the buffer to be just secretkey. So serialize/deserialize on it was working fine. But if the buffer had data past the secretkey it failed. Because it want to use all of it (more than 32 bytes).