### PR TITLE
feat: use pre-computation tables for extended commitment factory with extension degree = 1

### DIFF
--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -4,7 +4,6 @@
 //! Pedersen commitment types and factories for Ristretto
 
 use curve25519_dalek::{
-    constants::RISTRETTO_BASEPOINT_TABLE,
     ristretto::RistrettoPoint,
     traits::{Identity, MultiscalarMul},
 };
@@ -12,8 +11,12 @@ use curve25519_dalek::{
 use crate::{
     commitment::{HomomorphicCommitment, HomomorphicCommitmentFactory},
     ristretto::{
-        constants::RISTRETTO_NUMS_TABLE_0,
-        pedersen::{PedersenCommitment, RISTRETTO_PEDERSEN_G, RISTRETTO_PEDERSEN_H},
+        pedersen::{
+            scalar_mul_with_pre_computation_tables,
+            PedersenCommitment,
+            RISTRETTO_PEDERSEN_G,
+            RISTRETTO_PEDERSEN_H,
+        },
         RistrettoPublicKey,
         RistrettoSecretKey,
     },
@@ -49,9 +52,9 @@ impl HomomorphicCommitmentFactory for PedersenCommitmentFactory {
 
     #[allow(non_snake_case)]
     fn commit(&self, k: &RistrettoSecretKey, v: &RistrettoSecretKey) -> PedersenCommitment {
-        // If we're using the default generators, speed it up using precomputation tables
+        // If we're using the default generators, speed it up using pre-computation tables
         let c = if (self.G, self.H) == (RISTRETTO_PEDERSEN_G, *RISTRETTO_PEDERSEN_H) {
-            &RISTRETTO_BASEPOINT_TABLE * &k.0 + &*RISTRETTO_NUMS_TABLE_0 * &v.0
+            scalar_mul_with_pre_computation_tables(&k.0, &v.0)
         } else {
             RistrettoPoint::multiscalar_mul(&[v.0, k.0], &[self.H, self.G])
         };

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -22,6 +22,7 @@ use crate::{
     ristretto::{
         constants::{RISTRETTO_NUMS_POINTS, RISTRETTO_NUMS_POINTS_COMPRESSED},
         pedersen::{
+            scalar_mul_with_pre_computation_tables,
             PedersenCommitment,
             RISTRETTO_PEDERSEN_G,
             RISTRETTO_PEDERSEN_G_COMPRESSED,
@@ -90,6 +91,10 @@ impl ExtendedPedersenCommitmentFactory {
     {
         if blinding_factors.is_empty() || blinding_factors.len() > self.extension_degree as usize {
             Err(CommitmentError::ExtensionDegree("blinding vector".to_string()))
+        } else if blinding_factors.len() == 1 &&
+            (self.g_base_vec[0], self.h_base) == (RISTRETTO_PEDERSEN_G, *RISTRETTO_PEDERSEN_H)
+        {
+            Ok(scalar_mul_with_pre_computation_tables(&blinding_factors[0], value))
         } else {
             let scalars = once(value).chain(blinding_factors);
             let g_base_head = self.g_base_vec.iter().take(blinding_factors.len());

--- a/src/ristretto/pedersen/mod.rs
+++ b/src/ristretto/pedersen/mod.rs
@@ -6,14 +6,15 @@
 use std::{borrow::Borrow, iter::Sum};
 
 use curve25519_dalek::{
-    constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
+    constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT, RISTRETTO_BASEPOINT_TABLE},
     ristretto::{CompressedRistretto, RistrettoPoint},
+    scalar::Scalar,
 };
 
 use crate::{
     commitment::HomomorphicCommitment,
     ristretto::{
-        constants::{RISTRETTO_NUMS_POINTS, RISTRETTO_NUMS_POINTS_COMPRESSED},
+        constants::{RISTRETTO_NUMS_POINTS, RISTRETTO_NUMS_POINTS_COMPRESSED, RISTRETTO_NUMS_TABLE_0},
         RistrettoPublicKey,
     },
 };
@@ -48,6 +49,10 @@ where T: Borrow<PedersenCommitment>
         let sum = RistrettoPublicKey::new_from_pk(total);
         HomomorphicCommitment(sum)
     }
+}
+
+pub(crate) fn scalar_mul_with_pre_computation_tables(k: &Scalar, v: &Scalar) -> RistrettoPoint {
+    &RISTRETTO_BASEPOINT_TABLE * k + &*RISTRETTO_NUMS_TABLE_0 * v
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Added use of pre-computation tables for commitment scalar multiplication to the Ristretto Pedersen extended commitment factory if extension degree = 1, similar to what is done for the normal Ristretto Pedersen commitment factory.