### PR TITLE
test: run feature CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,16 +28,14 @@ jobs:
         with:
           command: test
           args: --release
-      - name: test/debug all features
-        if: ${{ matrix.rust != 'stable' }}
+      - name: test/debug features
         uses: actions-rs/cargo@v1
         with:
           command: test
           # TODO: re-add all features once https://github.com/rust-lang/packed_simd/pull/341 is used by dalek
           # args: --all-features
-          args: --features wasm --features ffi
-      - name: test/release all features
-        if: ${{ matrix.rust != 'stable' }}
+          args: --features wasm --features ffi --features borsh
+      - name: test/release features
         uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
Currently, no features are subject to CI testing. This is bad.

The CI system now runs only on `stable`. All feature-based CI tests are stuck behind an `if` clause that prohibits testing on `stable`, presumably because of an earlier version that used `--all-features` instead of selectively enabling them. This means they are never run.

This PR ensures that the feature tests for `wasm` and `ffi` and `borsh` are run.