### PR TITLE
feat: require secret keys to be zeroized on drop

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -11,7 +11,7 @@ use std::ops::Add;
 use rand::{CryptoRng, Rng};
 use serde::{de::DeserializeOwned, ser::Serialize};
 use tari_utilities::ByteArray;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// A trait specifying common behaviour for representing `SecretKey`s. Specific elliptic curve
 /// implementations need to implement this trait for them to be used in Tari.
@@ -27,7 +27,9 @@ use zeroize::Zeroize;
 /// let k = RistrettoSecretKey::random(&mut rng);
 /// let p = RistrettoPublicKey::from_secret_key(&k);
 /// ```
-pub trait SecretKey: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default + Zeroize {
+pub trait SecretKey:
+    ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default + Zeroize + ZeroizeOnDrop
+{
     /// The length of the key, in bytes
     fn key_length() -> usize;
     /// Generates a random secret key

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -23,7 +23,7 @@ use digest::Digest;
 use once_cell::sync::OnceCell;
 use rand::{CryptoRng, Rng};
 use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, Hashable};
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
     errors::HashingError,
@@ -52,8 +52,7 @@ use crate::{
 /// let _k2 = RistrettoSecretKey::from_hex(&"100000002000000030000000040000000");
 /// let _k3 = RistrettoSecretKey::random(&mut rng);
 /// ```
-#[derive(Eq, Clone, Default, Zeroize)]
-#[zeroize(drop)]
+#[derive(Eq, Clone, Default, Zeroize, ZeroizeOnDrop)]
 pub struct RistrettoSecretKey(pub(crate) Scalar);
 
 #[cfg(feature = "borsh")]


### PR DESCRIPTION
Adds a trait bound requiring that a `SecretKey` zeroize on drop. Derives this trait bound for `RistrettoSecretKey`.

Currently, we use a macro from `zeroize` to zeroize a `RistrettoSecretKey` on drop. This works fine, but doesn't let us require this behavior as a `SecretKey` trait bound. Now that we have a custom curve library fork that supports an updated version of `zeroize`, we can take advantage of a new `ZeroizeOnDrop` derive macro that adds a corresponding marker trait. This PR adds the marker trait as a trait bound to `SecretKey` and uses the derive macro for `RistrettoSecretKey`. This adds an additional layer of safety to secret keys.

Closes [issue #147](https://github.com/tari-project/tari-crypto/issues/147).