### PR TITLE
chore: fix lint warnings

### DIFF
--- a/lints.toml
+++ b/lints.toml
@@ -26,7 +26,7 @@ deny = [
     'clippy::else_if_without_else',
     'clippy::enum_glob_use',
     'clippy::inline_always',
-    'clippy::let_underscore_drop',
+    'let_underscore_drop',
     'clippy::let_unit_value',
     'clippy::match_on_vec_items',
     'clippy::match_wild_err_arm',

--- a/src/ristretto/bulletproofs_plus.rs
+++ b/src/ristretto/bulletproofs_plus.rs
@@ -194,8 +194,7 @@ impl BulletproofsPlusService {
                 },
                 Err(e) => {
                     return Err(RangeProofError::InvalidRangeProof(format!(
-                        "Range proof at index '{}' could not be deserialized ({})",
-                        i, e
+                        "Range proof at index '{i}' could not be deserialized ({e})"
                     )));
                 },
             }
@@ -384,8 +383,7 @@ impl ExtendedRangeProofService for BulletproofsPlusService {
             },
             Err(e) => {
                 return Err(RangeProofError::InvalidRangeProof(format!(
-                    "Internal range proof(s) error ({})",
-                    e
+                    "Internal range proof(s) error ({e})"
                 )))
             },
         };
@@ -412,8 +410,7 @@ impl ExtendedRangeProofService for BulletproofsPlusService {
         ) {
             Ok(_) => Ok(()),
             Err(e) => Err(RangeProofError::InvalidRangeProof(format!(
-                "Internal range proof(s) error ({})",
-                e
+                "Internal range proof(s) error ({e})"
             ))),
         }
     }
@@ -458,14 +455,12 @@ impl ExtendedRangeProofService for BulletproofsPlusService {
                         }
                     },
                     Err(e) => Err(RangeProofError::InvalidRangeProof(format!(
-                        "Internal range proof error ({})",
-                        e
+                        "Internal range proof error ({e})"
                     ))),
                 }
             },
             Err(e) => Err(RangeProofError::InvalidRangeProof(format!(
-                "Range proof could not be deserialized ({})",
-                e
+                "Range proof could not be deserialized ({e})"
             ))),
         }
     }
@@ -496,14 +491,12 @@ impl ExtendedRangeProofService for BulletproofsPlusService {
                         }
                     },
                     Err(e) => Err(RangeProofError::InvalidRangeProof(format!(
-                        "Internal range proof error ({})",
-                        e
+                        "Internal range proof error ({e})"
                     ))),
                 }
             },
             Err(e) => Err(RangeProofError::InvalidRangeProof(format!(
-                "Range proof could not be deserialized ({})",
-                e
+                "Range proof could not be deserialized ({e})"
             ))),
         }
     }

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -861,7 +861,7 @@ mod test {
     fn pubkey_display_width_formatting() {
         let hex = "e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76";
         let pk = RistrettoPublicKey::from_hex(hex).unwrap();
-        assert_eq!(format!("{:0}", pk), hex);
+        assert_eq!(format!("{pk:0}"), hex);
         assert_eq!(format!("{pk:2}"), "e2");
         assert_eq!(format!("{pk:6}"), "e2f2ae");
         assert_eq!(format!("{pk:7}"), "e2...76");


### PR DESCRIPTION
Fixes lint warnings. These weren't errors that failed CI, but clogged up the linter output.