### PR TITLE
feat: `RistrettoSecretKey` inversion

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -34,6 +34,8 @@ pub trait SecretKey:
     fn key_length() -> usize;
     /// Generates a random secret key
     fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self;
+    /// Get the multiplicative inverse of a nonzero secret key
+    fn invert(&self) -> Option<Self>;
 }
 
 //----------------------------------------   Public Keys  ----------------------------------------//

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -34,8 +34,6 @@ pub trait SecretKey:
     fn key_length() -> usize;
     /// Generates a random secret key
     fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self;
-    /// Get the multiplicative inverse of a nonzero secret key
-    fn invert(&self) -> Option<Self>;
 }
 
 //----------------------------------------   Public Keys  ----------------------------------------//

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -83,16 +83,6 @@ impl SecretKey for RistrettoSecretKey {
     fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         RistrettoSecretKey(Scalar::random(rng))
     }
-
-    /// Get the inverse of a nonzero secret key
-    /// If zero is passed, returns `None`; annoying, but a useful guardrail
-    fn invert(&self) -> Option<Self> {
-        if self.0 == Scalar::zero() {
-            None
-        } else {
-            Some(RistrettoSecretKey(self.0.invert()))
-        }
-    }
 }
 
 //-------------------------------------  Ristretto Secret Key ByteArray  ---------------------------------------------//
@@ -147,6 +137,16 @@ impl RistrettoSecretKey {
     /// Make a secret key printable.
     pub fn reveal(&self) -> RevealedSecretKey<'_> {
         RevealedSecretKey { secret: self }
+    }
+
+    /// Get the multiplicative inverse of a nonzero secret key
+    /// If zero is passed, returns `None`; annoying, but a useful guardrail
+    pub fn invert(&self) -> Option<Self> {
+        if self.0 == Scalar::zero() {
+            None
+        } else {
+            Some(RistrettoSecretKey(self.0.invert()))
+        }
     }
 }
 


### PR DESCRIPTION
Adds multiplicative inversion to `RistrettoSecretKey`. Adds a few unit tests.

Note that the underlying `invert` functionality from `curve25519-dalek` does not assert that the `Scalar` in question is nonzero, but requires the caller to check this; inverting zero is undefined. This PR specifically checks this, and as a result, the inversion returns an `Option`. This is probably annoying for the caller, but might stop bad things from happening.