### PR TITLE
test: revert and freeze `wasm-pack` module

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,7 +20,7 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
       - name: install wasm-pack
-        run: npm install -g wasm-pack
+        run: npm install -g wasm-pack@0.10.3
       - name: make wasm
         run: make wasm
       - name: make wasm-node

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,4 +65,4 @@ path = "benches/mod.rs"
 harness = false
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Oz", "--enable-mutable-globals"]
+wasm-opt = ["-Oz"]


### PR DESCRIPTION
There's an issue with WASM builds and tests on the current 0.11.0 version of the `wasm-pack` Node.js module that isn't present in the 0.10.3 version.

Until that issue is fixed upstream, this PR reverts to and freezes at the known working version.