### PR TITLE
fix: dependency on multiple versions of rand_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ log = "0.4.0"
 merlin = { version = "2.0.1", default-features = false }
 once_cell = "1.8.0"
 rand = { version = "0.7.3", default-features = false }
-rand_chacha = "0.3.1"
-rand_core = "0.6.4"
+rand_chacha = "0.2"
+rand_core = "0.5.1"
 serde = "1.0"
 serde_json = "1.0"
 serde-wasm-bindgen = { version = "0.4", optional = true }
@@ -39,7 +39,7 @@ zeroize = "1"
 [dev-dependencies]
 bincode = "1.1.4"
 criterion = "0.3.4"
-rand_chacha = "0.3.1"
+rand_chacha = "0.2"
 sha2 = "0.9.5"
 wasm-bindgen-test = "0.3.24"
 

--- a/src/hash/blake2.rs
+++ b/src/hash/blake2.rs
@@ -11,9 +11,9 @@ use digest::{
     Reset,
     Update,
 };
-use crate::hashing::LengthExtensionAttackResistant;
 
 use super::error::HashError;
+use crate::hashing::LengthExtensionAttackResistant;
 
 /// A convenience wrapper produce 256 bit hashes from Blake2b
 #[derive(Clone, Debug)]
@@ -72,7 +72,6 @@ impl Update for Blake256 {
 }
 
 impl LengthExtensionAttackResistant for Blake256 {}
-
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Fixed dependency on multiple versions of `rand_core` by downgrading `rand_chacha` and the direct reference to `rand_core`.

This is important to mitigate dependency clashes in future.