### PR TITLE
feat!: range proof API change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.10.1"
 blake2 = "0.9.1"
 borsh = { version = "0.9.3", optional = true }
 bulletproofs = { package = "tari_bulletproofs", version= "4.4.1" }
-bulletproofs_plus = { package = "tari_bulletproofs_plus", version="0.2.3"  }
+bulletproofs_plus = { git = "https://github.com/AaronFeickert/bulletproofs-plus.git", branch = "offloading", package = "tari_bulletproofs_plus" }
 curve25519-dalek = {package="tari-curve25519-dalek", version = "4.0.2", default-features = false, features = ["serde", "alloc"] }
 digest = "0.9.0"
 getrandom = { version = "0.2.3", default-features = false, optional = true }


### PR DESCRIPTION
A pending [pull request](https://github.com/tari-project/bulletproofs-plus/pull/29) in the `bulletproofs-plus` repository changes the range proof API to better support [proof offloading](https://github.com/tari-project/bulletproofs-plus/issues/27) more safely. In particular, it requires the use of two seed nonces for mask recovery, and changes these to be byte arrays in order to be more abstract to the underlying elliptic curve group, and more efficient.

This work makes an update to support the new API.