### PR TITLE
build: update `wasm-pack`

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,7 +20,7 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
       - name: install wasm-pack
-        run: npm install -g wasm-pack@0.10.3
+        run: npm install -g wasm-pack@0.11.1
       - name: make wasm
         run: make wasm
       - name: make wasm-node


### PR DESCRIPTION
Previously, an upstream [issue](https://github.com/rustwasm/wasm-pack/issues/1248) with `wasm-pack` resulted in CI failure. Because of this, the dependency was [reverted and frozen](https://github.com/tari-project/tari-crypto/pull/174) at a working version.

A recent `wasm-pack` minor version bump should have this working again. This PR updates and freezes at this version.