### PR TITLE
feat!: expose secret key length as a constant

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -30,8 +30,14 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 pub trait SecretKey:
     ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default + Zeroize + ZeroizeOnDrop
 {
-    /// The length of the key, in bytes
-    fn key_length() -> usize;
+    /// The encoded length of the key, in bytes
+    const KEY_LEN: usize;
+
+    /// The encoded length of the key, in bytes
+    fn key_length() -> usize {
+        Self::KEY_LEN
+    }
+
     /// Generates a random secret key
     fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self;
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -30,10 +30,10 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 pub trait SecretKey:
     ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default + Zeroize + ZeroizeOnDrop
 {
-    /// The encoded length of the key, in bytes
+    /// The length of the byte encoding of a key, in bytes
     const KEY_LEN: usize;
 
-    /// The encoded length of the key, in bytes
+    /// The length of the byte encoding of a key, in bytes
     fn key_length() -> usize {
         Self::KEY_LEN
     }
@@ -51,7 +51,7 @@ pub trait SecretKey:
 pub trait PublicKey:
     ByteArray + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Serialize + DeserializeOwned + Zeroize
 {
-    /// The output size len of Public Key
+    /// The length of the byte encoding of a key, in bytes
     const KEY_LEN: usize;
 
     /// The related [SecretKey](trait.SecretKey.html) type
@@ -61,7 +61,7 @@ pub trait PublicKey:
     /// failure does occur (implementation error?), the function will panic.
     fn from_secret_key(k: &Self::K) -> Self;
 
-    /// The length of the public key when converted to bytes
+    /// The length of the byte encoding of a key, in bytes
     fn key_length() -> usize {
         Self::KEY_LEN
     }

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -70,14 +70,9 @@ impl borsh::BorshDeserialize for RistrettoSecretKey {
     }
 }
 
-const SCALAR_LENGTH: usize = 32;
-const PUBLIC_KEY_LENGTH: usize = 32;
-
 //-----------------------------------------   Ristretto Secret Key    ------------------------------------------------//
 impl SecretKey for RistrettoSecretKey {
-    fn key_length() -> usize {
-        SCALAR_LENGTH
-    }
+    const KEY_LEN: usize = 32;
 
     /// Return a random secret key on the `ristretto255` curve using the supplied CSPRNG.
     fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
@@ -364,7 +359,7 @@ impl DomainSeparation for RistrettoGeneratorPoint {
 impl PublicKey for RistrettoPublicKey {
     type K = RistrettoSecretKey;
 
-    const KEY_LEN: usize = PUBLIC_KEY_LENGTH;
+    const KEY_LEN: usize = 32;
 
     /// Generates a new Public key from the given secret key
     fn from_secret_key(k: &Self::K) -> RistrettoPublicKey {


### PR DESCRIPTION
Currently, the `PublicKey` trait exposes the encoded key byte length via the associated `KEY_LEN` constant, and also provides it via the `key_length` function. However, the `SecretKey` trait only exposes its encoded key byte length via the `key_length` function, which cannot be constant. There are use cases where it's handy to get the key size at compile time, particularly when you want to use arrays and avoid heap allocations.

This PR unifies the `PublicKey` and `SecretKey` traits by adding an associated `KEY_LEN` constant to `SecretKey`. It then updates the `RistrettoSecretKey` implementation accordingly. This retains all existing functionality, so the change is not breaking.