### PR TITLE
chore(version): v0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["cryptography"]
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2018"
 
 [dependencies]

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.18.0](https://github.com/tari-project/tari-crypto/compare/v0.17.0...v0.18.0) (2023-07-18)
+
+
+### Features
+
+* remove unused dalek rangeproof ([#184](https://github.com/tari-project/tari-crypto/issues/184)) ([d21cd37](https://github.com/tari-project/tari-crypto/commit/d21cd377616776743b6e33552000cfc9fc06c0bd))
+* update dependancies ([#185](https://github.com/tari-project/tari-crypto/issues/185)) ([4c2424f](https://github.com/tari-project/tari-crypto/commit/4c2424f2f0426f9ad4a55a9ed35ecd29fe87e0c7))
+
 ## [0.17.0](https://github.com/tari-project/tari-crypto/compare/v0.16.12...v0.17.0) (2023-06-13)
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [0.18.0](https://github.com/tari-project/tari-crypto/compare/v0.17.0...v0.18.0) (2023-07-18)
 
+### ⚠ BREAKING CHANGES
+
+* Update of dependancies to mayor new versions (#185)
 
 ### Features
 


### PR DESCRIPTION
# [0.18.0](https://github.com/tari-project/tari-crypto/compare/v0.17.0...v0.18.0) (2023-07-18)


### Features

* remove unused dalek rangeproof ([184](https://github.com/tari-project/tari-crypto/issues/184)) ([d21cd37](https://github.com/tari-project/tari-crypto/commit/d21cd377616776743b6e33552000cfc9fc06c0bd))
* update dependancies ([185](https://github.com/tari-project/tari-crypto/issues/185)) ([4c2424f](https://github.com/tari-project/tari-crypto/commit/4c2424f2f0426f9ad4a55a9ed35ecd29fe87e0c7))