### PR TITLE
feat: zeroize temporary scalar byte array

### DIFF
--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -26,7 +26,7 @@ use digest::{
 use once_cell::sync::OnceCell;
 use rand::{CryptoRng, Rng};
 use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, Hashable};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::{
     errors::HashingError,
@@ -98,6 +98,7 @@ impl ByteArray for RistrettoSecretKey {
         let mut a = [0u8; 32];
         a.copy_from_slice(bytes);
         let k = Scalar::from_bytes_mod_order(a);
+        a.zeroize();
         Ok(RistrettoSecretKey(k))
     }
 


### PR DESCRIPTION
Currently, construction of a `RistrettoSecretKey` from a byte slice creates a temporary array that is passed into the Ristretto constructor. This PR zeroizes the array to reduce the risk of secret data exposure.