### PR TITLE
chore: fix a spurious lint

### DIFF
--- a/src/ristretto/bulletproofs_plus.rs
+++ b/src/ristretto/bulletproofs_plus.rs
@@ -538,7 +538,7 @@ impl ExtendedRangeProofService for BulletproofsPlusService {
 
 #[cfg(test)]
 mod test {
-    use std::{borrow::Borrow, collections::HashMap};
+    use std::collections::HashMap;
 
     use bulletproofs_plus::protocols::scalar_protocol::ScalarProtocol;
     use curve25519_dalek::scalar::Scalar;
@@ -615,8 +615,9 @@ mod test {
                             value >> (bit_length - 1) <= 1
                         {
                             assert!(proof.is_ok());
-                            assert!(bulletproofs_plus_service
-                                .verify(&proof.unwrap(), factory.commit_value(&key, value).borrow()));
+                            assert!(
+                                bulletproofs_plus_service.verify(&proof.unwrap(), &factory.commit_value(&key, value))
+                            );
                         } else {
                             assert!(proof.is_err());
                         }


### PR DESCRIPTION
There's a warning about an allegedly suspicious borrow in one of the range proof tests. It's likely [already fixed](https://github.com/rust-lang/rust/issues/112489), but easy enough to use the ampersand operator to clean up the warning.