### PR TITLE
feat!: enable no_std support for tari_crypto

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -35,3 +35,16 @@ jobs:
         with:
           command: check
           args: --release --all-targets
+      - name: Cargo check no default
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --release --no-default-features
+      # This check here is to ensure that it builds for no-std rust targets
+      - name: Cargo check for no-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          toolchain: nightly
+          args: --no-default-features --target=thumbv8m.main-none-eabi -Zavoid-dev-deps
+

--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -13,6 +13,13 @@ jobs:
           components: clippy, rustfmt
           toolchain: nightly
           override: true
+      - name: Toolchain thumbv8m.main-none-eabi
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: thumbv8m.main-none-eabi
+          override: true
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ version = "0.17.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git",  rev = "c06726322683c4671b93388b444d108103cd7b55", default-features = false, features = ["zero"] }
+tari_utilities = { version = "0.5", features = ["zero"] }
 blake2 = { version = "0.10", default-features = false  }
 borsh = { version = "0.10" , optional = true , default-features = false}
-bulletproofs_plus = { package = "tari_bulletproofs_plus", version = "0.3" }
+bulletproofs_plus = { package = "tari_bulletproofs_plus", version = "0.3", optional = true }
 curve25519-dalek = { package = "tari-curve25519-dalek",  version = "4.0.3", default-features = false, features = [ "alloc", "rand_core", "precomputed-tables", "zeroize"] }
 digest = { version = "0.10", default-features = false }
 log = { version = "0.4" , default-features = false}
@@ -27,7 +27,7 @@ snafu = { version = "0.7", default-features = false}
 zeroize = {version = "1" , default-features = false}
 
 [dev-dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git",  rev = "c06726322683c4671b93388b444d108103cd7b55", features = ["std"] }
+tari_utilities = { version = "0.5", features = ["std"] }
 serde = { version = "1.0"}
 bincode = { version = "1.1" }
 criterion = { version = "0.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.17.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { version = "0.5", features = ["zero", "std"] }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git",  rev = "c06726322683c4671b93388b444d108103cd7b55", features = ["zero", "std"] }
 blake2 = { version = "0.10" }
 borsh = { version = "0.10" , optional = true }
 bulletproofs_plus = { package = "tari_bulletproofs_plus", version = "0.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.17.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { version = "0.5", features = ["zero"] }
+tari_utilities = { version = "0.5", default-features = false, features = ["zero"] }
 blake2 = { version = "0.10", default-features = false  }
 borsh = { version = "0.10" , optional = true , default-features = false}
 bulletproofs_plus = { package = "tari_bulletproofs_plus", version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,7 @@ rand = { version = "0.8" }
 
 
 [features]
-default = ["std", "serde", "precomputed_tables"]
-std = ["bulletproofs_plus"]
+default = ["bulletproofs_plus", "serde", "precomputed_tables"]
 precomputed_tables = []
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,35 +11,39 @@ version = "0.17.0"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git",  rev = "c06726322683c4671b93388b444d108103cd7b55", features = ["zero", "std"] }
-blake2 = { version = "0.10" }
-borsh = { version = "0.10" , optional = true }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git",  rev = "c06726322683c4671b93388b444d108103cd7b55", default-features = false, features = ["zero"] }
+blake2 = { version = "0.10", default-features = false  }
+borsh = { version = "0.10" , optional = true , default-features = false}
 bulletproofs_plus = { package = "tari_bulletproofs_plus", version = "0.3" }
-curve25519-dalek = { package = "tari-curve25519-dalek",  version = "4.0.3", default-features = false, features = ["serde", "alloc", "rand_core", "precomputed-tables"] }
-digest = { version = "0.10" }
-lazy_static = { version = "1.3" }
-log = { version = "0.4" }
-once_cell = { version = "1.8" }
-rand_chacha = { version = "0.3" }
-rand_core = { version = "0.6" }
-serde = { version = "1.0" }
-sha3 = { version = "0.10" }
-thiserror = { version = "1.0" }
-zeroize = {version = "1" }
-rand = { version = "0.8" }
+curve25519-dalek = { package = "tari-curve25519-dalek",  version = "4.0.3", default-features = false, features = [ "alloc", "rand_core", "precomputed-tables", "zeroize"] }
+digest = { version = "0.10", default-features = false }
+log = { version = "0.4" , default-features = false}
+once_cell = { version = "1.8", default-features = false, features = ["critical-section"] }
+rand_chacha = { version = "0.3", default-features = false }
+rand_core = { version = "0.6" , default-features = false}
+serde = { version = "1.0", optional = true }
+sha3 = { version = "0.10", default-features = false  }
+snafu = { version = "0.7", default-features = false}
+zeroize = {version = "1" , default-features = false}
 
 [dev-dependencies]
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git",  rev = "c06726322683c4671b93388b444d108103cd7b55", features = ["std"] }
+serde = { version = "1.0"}
 bincode = { version = "1.1" }
 criterion = { version = "0.5", default-features = false }
 sha2 = { version = "0.10" }
+rand = { version = "0.8" }
 
 
 [features]
+default = ["std", "serde", "precomputed_tables"]
+std = ["bulletproofs_plus"]
+precomputed_tables = []
 
 [lib]
 # Disable benchmarks to allow Criterion to take over
 bench = false
-crate-type = ["lib", "cdylib", "staticlib"]
+crate-type = ["lib", "cdylib"]
 
 [[bench]]
 name = "benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rand = { version = "0.8" }
 
 
 [features]
-default = ["bulletproofs_plus", "serde", "precomputed_tables"]
+default = ["bulletproofs_plus", "serde", "precomputed_tables", "borsh"]
 precomputed_tables = []
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -11,9 +11,26 @@ Major features of this library include:
 - Pedersen commitments
 - Schnorr Signatures
 - Generic Public and Secret Keys
+- no-std support
 
 The `tari_crypto` crate makes heavy use of the excellent [Dalek](https://github.com/dalek-cryptography/curve25519-dalek)
 libraries. The default implementation for Tari ECC is the [Ristretto255 curve](https://ristretto.group).
+
+# Feature flags
+### bulletproofs_plus
+This adds in support for rangeproofs using the tari bulletproof plus library
+### serde
+This adds serialise and deserialize support for all structs using the serde library 
+### borsh
+This adds serialise and deserialize support for all structs using the borsh library
+### precomputed_tables
+This uses optimised precomputed tables for calculations. While this is faster than straight-up calculations, this requires large memory to store which is not ideal for small no_std devices
+
+# WASM and FFI support
+TariCrypto has external WASM and FFI wrappers available here
+WASM: https://github.com/tari-project/tari-crypto-wasm
+FFI: https://github.com/tari-project/tari-crypto-ffi
+
 # Benchmarks
 
 To run the benchmarks:

--- a/benches/signatures.rs
+++ b/benches/signatures.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{thread_rng, RngCore};
+use rand_core::OsRng;
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
@@ -45,7 +46,7 @@ fn sign_message(c: &mut Criterion) {
         b.iter_batched(
             gen_keypair,
             |d| {
-                let _sig = RistrettoSchnorr::sign_message(&d.k, d.m).unwrap();
+                let _sig = RistrettoSchnorr::sign_message(&d.k, d.m, &mut OsRng).unwrap();
             },
             BatchSize::SmallInput,
         );
@@ -59,7 +60,7 @@ fn verify_message(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let d = gen_keypair();
-                let s = RistrettoSchnorr::sign_message(&d.k, d.m).unwrap();
+                let s = RistrettoSchnorr::sign_message(&d.k, d.m, &mut OsRng).unwrap();
                 (d, s)
             },
             |(d, s)| assert!(s.verify_message(&d.p, d.m)),

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -13,8 +13,6 @@ use core::{
     ops::{Add, Mul, Sub},
 };
 
-#[cfg(feature = "borsh")]
-use borsh::maybestd::io;
 use tari_utilities::{ByteArray, ByteArrayError};
 
 use crate::{
@@ -40,15 +38,15 @@ pub struct HomomorphicCommitment<P>(pub(crate) P);
 
 #[cfg(feature = "borsh")]
 impl<P: borsh::BorshDeserialize> borsh::BorshDeserialize for HomomorphicCommitment<P> {
-    fn deserialize_reader<R>(reader: &mut R) -> Result<Self, io::Error>
-    where R: io::Read {
+    fn deserialize_reader<R>(reader: &mut R) -> Result<Self, borsh::maybestd::io::Error>
+    where R: borsh::maybestd::io::Read {
         Ok(Self(P::deserialize_reader(reader)?))
     }
 }
 
 #[cfg(feature = "borsh")]
 impl<P: borsh::BorshSerialize> borsh::BorshSerialize for HomomorphicCommitment<P> {
-    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+    fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W) -> borsh::maybestd::io::Result<()> {
         self.0.serialize(writer)
     }
 }

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -6,17 +6,19 @@
 //! envelope and reveal its contents. Also it's a special envelope that can only be opened by a special opener that
 //! you keep safe in your drawer.
 
-use std::{
+use core::{
     cmp::Ordering,
     convert::TryFrom,
     hash::{Hash, Hasher},
     ops::{Add, Mul, Sub},
 };
 
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "borsh")]
+use borsh::maybestd::io;
 use tari_utilities::{ByteArray, ByteArrayError};
 
 use crate::{
+    alloc::string::ToString,
     errors::CommitmentError,
     keys::{PublicKey, SecretKey},
 };
@@ -32,20 +34,21 @@ use crate::{
 ///   C_2 &= v_2.H + k_2.G \\\\
 ///   \therefore C_1 + C_2 &= (v_1 + v_2)H + (k_1 + k_2)G
 /// \end{aligned} $$
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HomomorphicCommitment<P>(pub(crate) P);
 
 #[cfg(feature = "borsh")]
 impl<P: borsh::BorshDeserialize> borsh::BorshDeserialize for HomomorphicCommitment<P> {
-    fn deserialize_reader<R>(reader: &mut R) -> Result<Self, std::io::Error>
-    where R: std::io::Read {
+    fn deserialize_reader<R>(reader: &mut R) -> Result<Self, io::Error>
+    where R: io::Read {
         Ok(Self(P::deserialize_reader(reader)?))
     }
 }
 
 #[cfg(feature = "borsh")]
 impl<P: borsh::BorshSerialize> borsh::BorshSerialize for HomomorphicCommitment<P> {
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
         self.0.serialize(writer)
     }
 }
@@ -251,9 +254,9 @@ impl ExtensionDegree {
             4 => Ok(ExtensionDegree::AddThreeBasePoints),
             5 => Ok(ExtensionDegree::AddFourBasePoints),
             6 => Ok(ExtensionDegree::AddFiveBasePoints),
-            _ => Err(CommitmentError::ExtensionDegree(
-                "Extension degree not valid".to_string(),
-            )),
+            _ => Err(CommitmentError::CommitmentExtensionDegree {
+                reason: "Extension degree not valid".to_string(),
+            }),
         }
     }
 }

--- a/src/deterministic_randomizer.rs
+++ b/src/deterministic_randomizer.rs
@@ -4,7 +4,8 @@
 //! A deterministic randomizer with utility functions for operating on numbers and arrays in a reproducible and
 //! platform-indepdent way.
 
-use std::convert::TryFrom;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 
 use rand_core::{CryptoRng, RngCore, SeedableRng};
 

--- a/src/dhke.rs
+++ b/src/dhke.rs
@@ -9,7 +9,7 @@
 //! clone the byte array without a very good reason. If you need the underlying public key itself, you probably should
 //! be using something else.
 
-use std::ops::Mul;
+use core::ops::Mul;
 
 use zeroize::Zeroize;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,65 +3,90 @@
 
 //! Errors used in the Tari Crypto crate
 
-use serde::{Deserialize, Serialize};
-use tari_utilities::ByteArrayError;
-use thiserror::Error;
+use alloc::string::String;
 
+use snafu::prelude::*;
 /// Errors encountered when creating of verifying range proofs
-#[derive(Debug, Clone, Error, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Snafu, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum RangeProofError {
     /// Cold not construct a range proof
-    #[error("Could not construct range proof: `{0}`")]
-    ProofConstructionError(String),
+    #[snafu(display("Could not construct range proof: `{reason}'"))]
+    ProofConstructionError {
+        /// The reason for the error
+        reason: String,
+    },
     /// The deserialization of the range proof failed
-    #[error("The deserialization of the range proof failed")]
-    InvalidProof,
+    #[snafu(display("The deserialization of the range proof failed"))]
+    InvalidProof {},
     /// Invalid input was provided to the RangeProofService constructor
-    #[error("Invalid input was provided to the RangeProofService constructor: `{0}`")]
-    InitializationError(String),
+    #[snafu(display("Invalid input was provided to the RangeProofService constructor: `{reason}'"))]
+    InitializationError {
+        /// The reason for the error
+        reason: String,
+    },
     /// Invalid range proof provided
-    #[error("Invalid range proof provided: `{0}`")]
-    InvalidRangeProof(String),
+    #[snafu(display("Invalid range proof provided: `{reason}"))]
+    InvalidRangeProof {
+        /// The reason for the error
+        reason: String,
+    },
     /// Invalid range proof rewind, the rewind keys provided must be invalid
-    #[error("Invalid range proof rewind, the rewind keys provided must be invalid")]
-    InvalidRewind(String),
+    #[snafu(display("Invalid range proof rewind, the rewind keys provided must be invalid: `{reason}'"))]
+    InvalidRewind {
+        /// The reason for the error
+        reason: String,
+    },
     /// Inconsistent extension degree
-    #[error("Inconsistent extension degree: `{0}`")]
-    ExtensionDegree(String),
+    #[snafu(display("Inconsistent extension degree: `{reason}'"))]
+    RPExtensionDegree {
+        /// The reason for the error
+        reason: String,
+    },
 }
 
 /// Errors encountered when committing values
-#[derive(Debug, Clone, Error, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Snafu, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CommitmentError {
     /// Inconsistent extension degree
-    #[error("Inconsistent extension degree: `{0}`")]
-    ExtensionDegree(String),
+    #[snafu(display("Inconsistent extension degree: `{reason}'"))]
+    CommitmentExtensionDegree {
+        /// The reason for the error
+        reason: String,
+    },
 }
 
 /// Errors encountered when hashing
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Snafu, PartialEq, Eq)]
 pub enum HashingError {
     /// The input to the hashing function is too short
-    #[error("The input to the hashing function is too short.")]
-    InputTooShort,
+    #[snafu(display("The input to the hashing function is too short."))]
+    InputTooShort {},
     /// Converting a byte string into a secret key failed
-    #[error("Converting a byte string into a secret key failed: {0}")]
-    ConversionFromBytes(String),
+    #[snafu(display("Converting a byte string into a secret key failed.  `{reason}'"))]
+    ConversionFromBytes {
+        /// The reason for the error
+        reason: String,
+    },
     /// The digest does not produce enough output
-    #[error("The digest does produce enough output. {0} bytes are required.")]
-    DigestTooShort(usize),
-}
-
-impl From<ByteArrayError> for HashingError {
-    fn from(byte_error: ByteArrayError) -> Self {
-        HashingError::ConversionFromBytes(byte_error.to_string())
-    }
+    #[snafu(display("The digest does produce enough output.`{bytes}' bytes are required."))]
+    DigestTooShort {
+        /// The number of bytes required
+        bytes: usize,
+    },
 }
 
 /// Errors encountered when copying to a buffer
-#[derive(Debug, Clone, Error, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Snafu, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SliceError {
     /// The requested fixed slice length exceeds the available slice length
-    #[error("Cannot create fixed slice of length {0} from a slice of length {1}.")]
-    CopyFromSlice(usize, usize),
+    #[snafu(display("Cannot create fixed slice of length '{target}' from a slice of length '{provided}'"))]
+    CopyFromSlice {
+        /// The requested fixed slice length
+        target: usize,
+        /// The available slice length
+        provided: usize,
+    },
 }

--- a/src/extended_range_proof.rs
+++ b/src/extended_range_proof.rs
@@ -3,6 +3,8 @@
 
 //! Extended range proofs
 
+use std::{string::ToString, vec::Vec};
+
 use crate::{
     commitment::{ExtensionDegree, HomomorphicCommitment},
     errors::RangeProofError,
@@ -110,9 +112,9 @@ where K: SecretKey
     /// Construct a new extended mask
     pub fn assign(extension_degree: ExtensionDegree, secrets: Vec<K>) -> Result<ExtendedMask<K>, RangeProofError> {
         if secrets.is_empty() || secrets.len() != extension_degree as usize {
-            Err(RangeProofError::InitializationError(
-                "Extended mask length must correspond to the extension degree".to_string(),
-            ))
+            Err(RangeProofError::InitializationError {
+                reason: "Extended mask length must correspond to the extension degree".to_string(),
+            })
         } else {
             Ok(Self { secrets })
         }
@@ -152,9 +154,9 @@ where PK: PublicKey
     /// - `statements` must be a power of 2 as mandated by the `bulletproofs_plus` implementation
     pub fn init(statements: Vec<Statement<PK>>) -> Result<Self, RangeProofError> {
         if !statements.len().is_power_of_two() {
-            return Err(RangeProofError::InitializationError(
-                "Number of commitments must be a power of two".to_string(),
-            ));
+            return Err(RangeProofError::InitializationError {
+                reason: "Number of commitments must be a power of two".to_string(),
+            });
         }
         Ok(Self { statements })
     }
@@ -180,14 +182,14 @@ where PK: PublicKey
     /// - mask recovery is not supported with an aggregated statement/proof
     pub fn init(statements: Vec<Statement<PK>>, recovery_seed_nonce: Option<PK::K>) -> Result<Self, RangeProofError> {
         if recovery_seed_nonce.is_some() && statements.len() > 1 {
-            return Err(RangeProofError::InitializationError(
-                "Mask recovery is not supported with an aggregated statement".to_string(),
-            ));
+            return Err(RangeProofError::InitializationError {
+                reason: "Mask recovery is not supported with an aggregated statement".to_string(),
+            });
         }
         if !statements.len().is_power_of_two() {
-            return Err(RangeProofError::InitializationError(
-                "Number of commitments must be a power of two".to_string(),
-            ));
+            return Err(RangeProofError::InitializationError {
+                reason: "Number of commitments must be a power of two".to_string(),
+            });
         }
         Ok(Self {
             statements,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -42,9 +42,12 @@ pub trait SecretKey:
 }
 
 //----------------------------------------   Public Keys  ----------------------------------------//
+
 #[cfg(not(feature = "serde"))]
+/// Supertraits for publickey trait. We use this so that we can make serde optional
 pub trait SuperPublicKey: ByteArray + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Zeroize {}
 #[cfg(feature = "serde")]
+/// Supertraits for publickey trait. We use this so that we can make serde optional
 pub trait SuperPublicKey:
     ByteArray
     + Add<Output = Self>

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -43,30 +43,11 @@ pub trait SecretKey:
 
 //----------------------------------------   Public Keys  ----------------------------------------//
 
-#[cfg(not(feature = "serde"))]
-/// Supertraits for publickey trait. We use this so that we can make serde optional
-pub trait SuperPublicKey: ByteArray + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Zeroize {}
-#[cfg(feature = "serde")]
-/// Supertraits for publickey trait. We use this so that we can make serde optional
-pub trait SuperPublicKey:
-    ByteArray
-    + Add<Output = Self>
-    + Clone
-    + PartialOrd
-    + Ord
-    + Default
-    + Zeroize
-    + serde::ser::Serialize
-    + serde::de::DeserializeOwned
-{
-}
-impl<T: PublicKey> SuperPublicKey for T {}
-
 /// A trait specifying common behaviour for representing `PublicKey`s. Specific elliptic curve
 /// implementations need to implement this trait for them to be used in Tari.
 ///
 /// See [SecretKey](trait.SecretKey.html) for an example.
-pub trait PublicKey: SuperPublicKey {
+pub trait PublicKey: ByteArray + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Zeroize {
     /// The length of the byte encoding of a key, in bytes
     const KEY_LEN: usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #[macro_use]
 extern crate alloc;
 
-#[cfg(any(feature = "wasm", feature = "ffi", feature = "std", test))]
+#[cfg(any(feature = "wasm", feature = "ffi", feature = "bulletproofs_plus", test))]
 #[macro_use]
 extern crate std;
 
@@ -19,9 +19,9 @@ pub mod deterministic_randomizer;
 pub mod dhke;
 pub mod hashing;
 pub mod keys;
-#[cfg(feature = "std")]
+#[cfg(feature = "bulletproofs_plus")]
 pub mod range_proof;
-#[cfg(feature = "std")]
+#[cfg(feature = "bulletproofs_plus")]
 pub mod rewindable_range_proof;
 pub mod signatures;
 
@@ -30,7 +30,7 @@ pub mod signatures;
 pub mod ristretto;
 
 pub mod errors;
-#[cfg(feature = "std")]
+#[cfg(feature = "bulletproofs_plus")]
 pub mod extended_range_proof;
 
 // Re-export tari_utils

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #[macro_use]
 extern crate alloc;
 
-#[cfg(any(feature = "wasm", feature = "ffi", feature = "bulletproofs_plus", test))]
+#[cfg(any(feature = "bulletproofs_plus", test))]
 #[macro_use]
 extern crate std;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 //! Tari-Crypto
+#![no_std]
 
+#[allow(unused_imports)]
 #[macro_use]
-extern crate lazy_static;
+extern crate alloc;
+
+#[cfg(any(feature = "wasm", feature = "ffi", feature = "std", test))]
+#[macro_use]
+extern crate std;
 
 #[macro_use]
 mod macros;
@@ -13,7 +19,9 @@ pub mod deterministic_randomizer;
 pub mod dhke;
 pub mod hashing;
 pub mod keys;
+#[cfg(feature = "std")]
 pub mod range_proof;
+#[cfg(feature = "std")]
 pub mod rewindable_range_proof;
 pub mod signatures;
 
@@ -22,6 +30,7 @@ pub mod signatures;
 pub mod ristretto;
 
 pub mod errors;
+#[cfg(feature = "std")]
 pub mod extended_range_proof;
 
 // Re-export tari_utils

--- a/src/ristretto/bulletproofs_plus.rs
+++ b/src/ristretto/bulletproofs_plus.rs
@@ -547,7 +547,7 @@ impl ExtendedRangeProofService for BulletproofsPlusService {
 
 #[cfg(test)]
 mod test {
-    use std::{borrow::Borrow, collections::HashMap, vec::Vec};
+    use std::{collections::HashMap, vec::Vec};
 
     use bulletproofs_plus::protocols::scalar_protocol::ScalarProtocol;
     use curve25519_dalek::scalar::Scalar;

--- a/src/ristretto/constants.rs
+++ b/src/ristretto/constants.rs
@@ -118,6 +118,7 @@ mod test {
     pub fn check_nums_points() {
         let n = RISTRETTO_NUMS_POINTS_COMPRESSED.len();
         let calculated_nums_points = nums_ristretto(n);
+        #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             // Should be equal to the NUMS constants
             assert_eq!(calculated_nums_points.0[i], ristretto_nums_points()[i]);
@@ -129,6 +130,7 @@ mod test {
             assert_ne!(RISTRETTO_BASEPOINT_POINT, ristretto_nums_points()[i]);
             assert_ne!(RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_NUMS_POINTS_COMPRESSED[i]);
             // Should all be unique
+            #[allow(clippy::needless_range_loop)]
             for j in i + 1..n {
                 assert_ne!(ristretto_nums_points()[i], ristretto_nums_points()[j]);
                 assert_ne!(RISTRETTO_NUMS_POINTS_COMPRESSED[i], RISTRETTO_NUMS_POINTS_COMPRESSED[j]);
@@ -140,11 +142,11 @@ mod test {
     #[test]
     pub fn check_tables() {
         // Perform test multiplications
-        assert_eq!(&*ristretto_nums_table_0() * &Scalar::ZERO, RistrettoPoint::identity());
+        assert_eq!(ristretto_nums_table_0() * &Scalar::ZERO, RistrettoPoint::identity());
 
         for j in 0..15u8 {
             assert_eq!(
-                &*ristretto_nums_table_0() * &Scalar::from(j),
+                ristretto_nums_table_0() * &Scalar::from(j),
                 ristretto_nums_points()[0] * Scalar::from(j)
             );
         }

--- a/src/ristretto/constants.rs
+++ b/src/ristretto/constants.rs
@@ -6,6 +6,7 @@
 //! Tests the correctness of the NUMS construction.
 
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoBasepointTable, RistrettoPoint};
+use once_cell::sync::OnceCell;
 
 const NUMBER_NUMS_POINTS: usize = 10;
 
@@ -56,22 +57,28 @@ pub const RISTRETTO_NUMS_POINTS_COMPRESSED: [CompressedRistretto; NUMBER_NUMS_PO
     ]),
 ];
 
-lazy_static! {
-    /// A static array of pre-generated NUMS points
-    pub static ref RISTRETTO_NUMS_POINTS: [RistrettoPoint; NUMBER_NUMS_POINTS] = {
+/// A static array of pre-generated NUMS points
+pub fn ristretto_nums_points() -> &'static [RistrettoPoint; NUMBER_NUMS_POINTS] {
+    static INSTANCE: OnceCell<[RistrettoPoint; NUMBER_NUMS_POINTS]> = OnceCell::new();
+    INSTANCE.get_or_init(|| {
         let mut arr = [RistrettoPoint::default(); NUMBER_NUMS_POINTS];
         for i in 0..NUMBER_NUMS_POINTS {
             arr[i] = RISTRETTO_NUMS_POINTS_COMPRESSED[i].decompress().unwrap();
         }
         arr
-    };
+    })
+}
 
-    /// Precomputation table for the first point, which is used as the default commitment generator
-    pub static ref RISTRETTO_NUMS_TABLE_0: RistrettoBasepointTable = RistrettoBasepointTable::create(&RISTRETTO_NUMS_POINTS[0]);
+/// Precomputation table for the first point, which is used as the default commitment generator
+pub fn ristretto_nums_table_0() -> &'static RistrettoBasepointTable {
+    static INSTANCE: OnceCell<RistrettoBasepointTable> = OnceCell::new();
+    INSTANCE.get_or_init(|| RistrettoBasepointTable::create(&ristretto_nums_points()[0]))
 }
 
 #[cfg(test)]
 mod test {
+    use alloc::vec::Vec;
+
     use curve25519_dalek::{
         constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
         ristretto::{CompressedRistretto, RistrettoPoint},
@@ -81,9 +88,9 @@ mod test {
     use sha2::{Digest, Sha512};
 
     use crate::ristretto::constants::{
-        RISTRETTO_NUMS_POINTS,
+        ristretto_nums_points,
+        ristretto_nums_table_0,
         RISTRETTO_NUMS_POINTS_COMPRESSED,
-        RISTRETTO_NUMS_TABLE_0,
     };
 
     /// Generate a set of NUMS points by hashing domain separation labels and converting the hash output to a Ristretto
@@ -105,7 +112,7 @@ mod test {
         (points, compressed_points)
     }
 
-    /// Confirm that the [RISTRETTO_NUM_POINTS array](Const.RISTRETTO_NUMS_POINTS.html) is generated with Nothing Up
+    /// Confirm that the [RISTRETTO_NUM_POINTS array](Const.ristretto_nums_points().html) is generated with Nothing Up
     /// My Sleeve (NUMS), unique, not equal to the identity value and not equal to the Ristretto base point.
     #[test]
     pub fn check_nums_points() {
@@ -113,17 +120,17 @@ mod test {
         let calculated_nums_points = nums_ristretto(n);
         for i in 0..n {
             // Should be equal to the NUMS constants
-            assert_eq!(calculated_nums_points.0[i], RISTRETTO_NUMS_POINTS[i]);
+            assert_eq!(calculated_nums_points.0[i], ristretto_nums_points()[i]);
             assert_eq!(calculated_nums_points.1[i], RISTRETTO_NUMS_POINTS_COMPRESSED[i]);
             // Should not be equal to the identity values
-            assert_ne!(RistrettoPoint::default(), RISTRETTO_NUMS_POINTS[i]);
+            assert_ne!(RistrettoPoint::default(), ristretto_nums_points()[i]);
             assert_ne!(CompressedRistretto::default(), RISTRETTO_NUMS_POINTS_COMPRESSED[i]);
             // Should not be equal to the Ristretto base point
-            assert_ne!(RISTRETTO_BASEPOINT_POINT, RISTRETTO_NUMS_POINTS[i]);
+            assert_ne!(RISTRETTO_BASEPOINT_POINT, ristretto_nums_points()[i]);
             assert_ne!(RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_NUMS_POINTS_COMPRESSED[i]);
             // Should all be unique
             for j in i + 1..n {
-                assert_ne!(RISTRETTO_NUMS_POINTS[i], RISTRETTO_NUMS_POINTS[j]);
+                assert_ne!(ristretto_nums_points()[i], ristretto_nums_points()[j]);
                 assert_ne!(RISTRETTO_NUMS_POINTS_COMPRESSED[i], RISTRETTO_NUMS_POINTS_COMPRESSED[j]);
             }
         }
@@ -133,12 +140,12 @@ mod test {
     #[test]
     pub fn check_tables() {
         // Perform test multiplications
-        assert_eq!(&*RISTRETTO_NUMS_TABLE_0 * &Scalar::ZERO, RistrettoPoint::identity());
+        assert_eq!(&*ristretto_nums_table_0() * &Scalar::ZERO, RistrettoPoint::identity());
 
         for j in 0..15u8 {
             assert_eq!(
-                &*RISTRETTO_NUMS_TABLE_0 * &Scalar::from(j),
-                RISTRETTO_NUMS_POINTS[0] * Scalar::from(j)
+                &*ristretto_nums_table_0() * &Scalar::from(j),
+                ristretto_nums_points()[0] * Scalar::from(j)
             );
         }
     }

--- a/src/ristretto/mod.rs
+++ b/src/ristretto/mod.rs
@@ -3,7 +3,7 @@
 
 //! This module contains implementations using the Ristretto curve.
 
-#[cfg(feature = "std")]
+#[cfg(feature = "bulletproofs_plus")]
 pub mod bulletproofs_plus;
 pub mod constants;
 pub mod pedersen;

--- a/src/ristretto/mod.rs
+++ b/src/ristretto/mod.rs
@@ -3,6 +3,7 @@
 
 //! This module contains implementations using the Ristretto curve.
 
+#[cfg(feature = "std")]
 pub mod bulletproofs_plus;
 pub mod constants;
 pub mod pedersen;
@@ -10,6 +11,7 @@ mod ristretto_com_and_pub_sig;
 mod ristretto_com_sig;
 pub mod ristretto_keys;
 mod ristretto_sig;
+#[cfg(feature = "serde")]
 pub mod serialize;
 pub mod utils;
 

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -314,6 +314,7 @@ mod test {
                 let k_vec = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];
                 let c_extended = factory.commit_extended(&k_vec, &v).unwrap();
                 let mut c_calc: RistrettoPoint = v.0 * H + k_vec[0].0 * RISTRETTO_PEDERSEN_G;
+                #[allow(clippy::needless_range_loop)]
                 for i in 1..(extension_degree as usize) {
                     c_calc += k_vec[i].0 * ristretto_nums_points()[i];
                 }

--- a/src/ristretto/pedersen/mod.rs
+++ b/src/ristretto/pedersen/mod.rs
@@ -61,7 +61,7 @@ where T: Borrow<PedersenCommitment>
 
 #[cfg(feature = "precomputed_tables")]
 pub(crate) fn scalar_mul_with_pre_computation_tables(k: &Scalar, v: &Scalar) -> RistrettoPoint {
-    RISTRETTO_BASEPOINT_TABLE * k + &*ristretto_nums_table_0() * v
+    RISTRETTO_BASEPOINT_TABLE * k + ristretto_nums_table_0() * v
 }
 
 #[cfg(test)]

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -12,8 +12,6 @@ use core::{
 };
 
 use blake2::Blake2b;
-#[cfg(feature = "borsh")]
-use borsh::maybestd::{io, io::Write};
 use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_TABLE,
     ristretto::{CompressedRistretto, RistrettoPoint},
@@ -58,17 +56,18 @@ pub struct RistrettoSecretKey(pub(crate) Scalar);
 
 #[cfg(feature = "borsh")]
 impl borsh::BorshSerialize for RistrettoSecretKey {
-    fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+    fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W) -> borsh::maybestd::io::Result<()> {
         borsh::BorshSerialize::serialize(&self.as_bytes(), writer)
     }
 }
 
 #[cfg(feature = "borsh")]
 impl borsh::BorshDeserialize for RistrettoSecretKey {
-    fn deserialize_reader<R>(reader: &mut R) -> Result<Self, io::Error>
-    where R: io::Read {
+    fn deserialize_reader<R>(reader: &mut R) -> Result<Self, borsh::maybestd::io::Error>
+    where R: borsh::maybestd::io::Read {
         let bytes: Vec<u8> = borsh::BorshDeserialize::deserialize_reader(reader)?;
-        Self::from_bytes(bytes.as_slice()).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))
+        Self::from_bytes(bytes.as_slice())
+            .map_err(|e| borsh::maybestd::io::Error::new(borsh::maybestd::io::ErrorKind::InvalidInput, e.to_string()))
     }
 }
 
@@ -264,17 +263,18 @@ pub struct RistrettoPublicKey {
 
 #[cfg(feature = "borsh")]
 impl borsh::BorshSerialize for RistrettoPublicKey {
-    fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+    fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W) -> borsh::maybestd::io::Result<()> {
         borsh::BorshSerialize::serialize(&self.as_bytes(), writer)
     }
 }
 
 #[cfg(feature = "borsh")]
 impl borsh::BorshDeserialize for RistrettoPublicKey {
-    fn deserialize_reader<R>(reader: &mut R) -> Result<Self, io::Error>
-    where R: io::Read {
+    fn deserialize_reader<R>(reader: &mut R) -> Result<Self, borsh::maybestd::io::Error>
+    where R: borsh::maybestd::io::Read {
         let bytes: Vec<u8> = borsh::BorshDeserialize::deserialize_reader(reader)?;
-        Self::from_bytes(bytes.as_slice()).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))
+        Self::from_bytes(bytes.as_slice())
+            .map_err(|e| borsh::maybestd::io::Error::new(borsh::maybestd::io::ErrorKind::InvalidInput, e.to_string()))
     }
 }
 

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -19,7 +19,7 @@ use curve25519_dalek::{
     traits::MultiscalarMul,
 };
 use digest::{consts::U64, Digest};
-use once_cell::unsync::OnceCell;
+use once_cell::sync::OnceCell;
 use rand_core::{CryptoRng, RngCore};
 use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, Hashable};
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 //! The Tari-compatible implementation of Ristretto based on the curve25519-dalek implementation
-use std::{
+use alloc::{string::ToString, vec::Vec};
+use core::{
     borrow::Borrow,
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
     ops::{Add, Mul, Sub},
 };
-#[cfg(feature = "borsh")]
-use std::{io, io::Write};
 
 use blake2::Blake2b;
+#[cfg(feature = "borsh")]
+use borsh::maybestd::{io, io::Write};
 use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_TABLE,
     ristretto::{CompressedRistretto, RistrettoPoint},
@@ -20,8 +21,8 @@ use curve25519_dalek::{
     traits::MultiscalarMul,
 };
 use digest::{consts::U64, Digest};
-use once_cell::sync::OnceCell;
-use rand::{CryptoRng, Rng};
+use once_cell::unsync::OnceCell;
+use rand_core::{CryptoRng, RngCore};
 use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, Hashable};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -76,7 +77,7 @@ impl SecretKey for RistrettoSecretKey {
     const KEY_LEN: usize = 32;
 
     /// Return a random secret key on the `ristretto255` curve using the supplied CSPRNG.
-    fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+    fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         RistrettoSecretKey(Scalar::random(rng))
     }
 }
@@ -298,7 +299,7 @@ impl RistrettoPublicKey {
         // This function requires 512 bytes of data, so let's be opinionated here and use blake2b
         let hash = DomainSeparatedHasher::<Blake2b<U64>, RistrettoGeneratorPoint>::new_with_label(label).finalize();
         if hash.as_ref().len() < 64 {
-            return Err(HashingError::DigestTooShort(64));
+            return Err(HashingError::DigestTooShort { bytes: 64 });
         }
         let mut bytes = [0u8; 64];
         bytes.copy_from_slice(hash.as_ref());
@@ -429,7 +430,7 @@ impl RistrettoPublicKey {
                 let right = hex.len() - (w - left - 3);
                 f.write_str(format!("{}...{}", &hex[..left], &hex[right..]).as_str())
             },
-            _ => std::fmt::Display::fmt(&hex, f),
+            _ => core::fmt::Display::fmt(&hex, f),
         }
     }
 }
@@ -598,7 +599,7 @@ impl From<RistrettoPublicKey> for CompressedRistretto {
 #[cfg(test)]
 mod test {
     use digest::consts::U32;
-    use tari_utilities::{message_format::MessageFormat, ByteArray};
+    use tari_utilities::ByteArray;
 
     use super::*;
     use crate::{keys::PublicKey, ristretto::test_common::get_keypair};
@@ -807,7 +808,7 @@ mod test {
         // can fail in release mode, even though the values were effectively scrubbed.
         if cfg!(debug_assertions) {
             unsafe {
-                use std::slice;
+                use core::slice;
                 assert_eq!(slice::from_raw_parts(ptr, 32), zero);
             }
         }
@@ -831,44 +832,48 @@ mod test {
             "00e1f50500000000000000000000000000000000000000000000000000000000"
         );
     }
+    #[cfg(feature = "serde")]
+    mod test_serialize {
+        use tari_utilities::message_format::MessageFormat;
 
-    #[test]
-    fn serialize_deserialize_base64() {
-        let mut rng = rand::thread_rng();
-        let (k, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let ser_k = k.to_base64().unwrap();
-        let ser_pk = pk.to_base64().unwrap();
-        let k2: RistrettoSecretKey = RistrettoSecretKey::from_base64(&ser_k).unwrap();
-        assert_eq!(k, k2, "Deserialised secret key");
-        let pk2: RistrettoPublicKey = RistrettoPublicKey::from_base64(&ser_pk).unwrap();
-        assert_completely_equal(&pk, &pk2);
+        use super::*;
+        #[test]
+        fn serialize_deserialize_base64() {
+            let mut rng = rand::thread_rng();
+            let (k, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+            let ser_k = k.to_base64().unwrap();
+            let ser_pk = pk.to_base64().unwrap();
+            let k2: RistrettoSecretKey = RistrettoSecretKey::from_base64(&ser_k).unwrap();
+            assert_eq!(k, k2, "Deserialised secret key");
+            let pk2: RistrettoPublicKey = RistrettoPublicKey::from_base64(&ser_pk).unwrap();
+            assert_completely_equal(&pk, &pk2);
+        }
+
+        #[test]
+        fn serialize_deserialize_json() {
+            let mut rng = rand::thread_rng();
+            let (k, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+            let ser_k = k.to_json().unwrap();
+            let ser_pk = pk.to_json().unwrap();
+            println!("JSON pubkey: {ser_pk} privkey: {ser_k}");
+            let k2: RistrettoSecretKey = RistrettoSecretKey::from_json(&ser_k).unwrap();
+            assert_eq!(k, k2, "Deserialised secret key");
+            let pk2: RistrettoPublicKey = RistrettoPublicKey::from_json(&ser_pk).unwrap();
+            assert_completely_equal(&pk, &pk2);
+        }
+
+        #[test]
+        fn serialize_deserialize_binary() {
+            let mut rng = rand::thread_rng();
+            let (k, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+            let ser_k = k.to_binary().unwrap();
+            let ser_pk = pk.to_binary().unwrap();
+            let k2: RistrettoSecretKey = RistrettoSecretKey::from_binary(&ser_k).unwrap();
+            assert_eq!(k, k2);
+            let pk2: RistrettoPublicKey = RistrettoPublicKey::from_binary(&ser_pk).unwrap();
+            assert_completely_equal(&pk, &pk2);
+        }
     }
-
-    #[test]
-    fn serialize_deserialize_json() {
-        let mut rng = rand::thread_rng();
-        let (k, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let ser_k = k.to_json().unwrap();
-        let ser_pk = pk.to_json().unwrap();
-        println!("JSON pubkey: {ser_pk} privkey: {ser_k}");
-        let k2: RistrettoSecretKey = RistrettoSecretKey::from_json(&ser_k).unwrap();
-        assert_eq!(k, k2, "Deserialised secret key");
-        let pk2: RistrettoPublicKey = RistrettoPublicKey::from_json(&ser_pk).unwrap();
-        assert_completely_equal(&pk, &pk2);
-    }
-
-    #[test]
-    fn serialize_deserialize_binary() {
-        let mut rng = rand::thread_rng();
-        let (k, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let ser_k = k.to_binary().unwrap();
-        let ser_pk = pk.to_binary().unwrap();
-        let k2: RistrettoSecretKey = RistrettoSecretKey::from_binary(&ser_k).unwrap();
-        assert_eq!(k, k2);
-        let pk2: RistrettoPublicKey = RistrettoPublicKey::from_binary(&ser_pk).unwrap();
-        assert_completely_equal(&pk, &pk2);
-    }
-
     #[test]
     fn display_and_debug() {
         let hex = "e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76";
@@ -964,7 +969,7 @@ mod test {
     #[test]
     fn kdf_key_too_short() {
         let err = RistrettoKdf::generate::<Blake2b<U32>>(b"this_key_is_too_short", b"data", "test").err();
-        assert!(matches!(err, Some(HashingError::InputTooShort)));
+        assert!(matches!(err, Some(HashingError::InputTooShort {})));
     }
 
     #[test]
@@ -1036,6 +1041,8 @@ mod test {
 
     #[cfg(feature = "borsh")]
     mod borsh {
+        use alloc::vec::Vec;
+
         use borsh::{BorshDeserialize, BorshSerialize};
 
         use crate::ristretto::{test_common::get_keypair, RistrettoPublicKey, RistrettoSecretKey};

--- a/src/ristretto/ristretto_sig.rs
+++ b/src/ristretto/ristretto_sig.rs
@@ -42,6 +42,7 @@ use crate::{
 /// # use tari_crypto::keys::*;
 /// # use tari_crypto::signatures::SchnorrSignature;
 /// # use digest::Digest;
+/// # use rand::{Rng, thread_rng};
 ///
 /// fn get_keypair() -> (RistrettoSecretKey, RistrettoPublicKey) {
 ///     let mut rng = rand::thread_rng();
@@ -53,7 +54,8 @@ use crate::{
 /// #[allow(non_snake_case)]
 /// let (k, P) = get_keypair();
 /// let msg = "Small Gods";
-/// let sig = RistrettoSchnorr::sign_message(&k, &msg);
+/// let mut rng = thread_rng();
+/// let sig = RistrettoSchnorr::sign_message(&k, &msg, &mut rng);
 /// ```
 ///
 /// # Verifying signatures
@@ -68,6 +70,7 @@ use crate::{
 /// # use tari_utilities::hex::*;
 /// # use tari_utilities::ByteArray;
 /// # use digest::Digest;
+/// # use rand::{Rng, thread_rng};
 ///
 /// let msg = "Maskerade";
 /// let k = RistrettoSecretKey::from_hex(
@@ -76,8 +79,9 @@ use crate::{
 /// .unwrap();
 /// # #[allow(non_snake_case)]
 /// let P = RistrettoPublicKey::from_secret_key(&k);
+/// let mut rng = thread_rng();
 /// let sig: SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey> =
-///     SchnorrSignature::sign_message(&k, msg).unwrap();
+///     SchnorrSignature::sign_message(&k, msg, &mut rng).unwrap();
 /// assert!(sig.verify_message(&P, msg));
 /// ```
 pub type RistrettoSchnorr = SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey, SchnorrSigChallenge>;
@@ -94,6 +98,7 @@ pub type RistrettoSchnorr = SchnorrSignature<RistrettoPublicKey, RistrettoSecret
 /// # use tari_crypto::hash_domain;
 /// # use tari_crypto::signatures::SchnorrSignature;
 /// # use tari_utilities::hex::*;
+/// # use rand::{Rng, thread_rng};
 /// # use tari_utilities::ByteArray;
 /// # use digest::Digest;
 ///
@@ -106,8 +111,9 @@ pub type RistrettoSchnorr = SchnorrSignature<RistrettoPublicKey, RistrettoSecret
 /// .unwrap();
 /// # #[allow(non_snake_case)]
 /// let P = RistrettoPublicKey::from_secret_key(&k);
+/// let mut rng = thread_rng();
 /// let sig: SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey, MyCustomDomain> =
-///     SchnorrSignature::sign_message(&k, msg).unwrap();
+///     SchnorrSignature::sign_message(&k, msg, &mut rng).unwrap();
 /// assert!(sig.verify_message(&P, msg));
 /// ```
 pub type RistrettoSchnorrWithDomain<H> = SchnorrSignature<RistrettoPublicKey, RistrettoSecretKey, H>;
@@ -261,7 +267,8 @@ mod test {
     fn sign_and_verify_message() {
         let mut rng = rand::thread_rng();
         let (k, P) = RistrettoPublicKey::random_keypair(&mut rng);
-        let sig = RistrettoSchnorr::sign_message(&k, "Queues are things that happen to other people").unwrap();
+        let sig =
+            RistrettoSchnorr::sign_message(&k, "Queues are things that happen to other people", &mut rng).unwrap();
         assert!(sig.verify_message(&P, "Queues are things that happen to other people"));
         assert!(!sig.verify_message(&P, "Qs are things that happen to other people"));
         assert!(!sig.verify_message(&(&P + &P), "Queues are things that happen to other people"));

--- a/src/ristretto/serialize.rs
+++ b/src/ristretto/serialize.rs
@@ -22,7 +22,8 @@
 //!   }
 //! ```
 
-use std::fmt;
+use alloc::string::String;
+use core::fmt;
 
 use serde::{
     de::{self, Visitor},

--- a/src/ristretto/utils.rs
+++ b/src/ristretto/utils.rs
@@ -3,7 +3,10 @@
 
 //! Handy utility functions for use in tests and demo scripts
 
+use alloc::vec::Vec;
+
 use digest::Digest;
+use rand_core::{CryptoRng, RngCore};
 use tari_utilities::ByteArray;
 
 use crate::{
@@ -33,12 +36,12 @@ pub struct SignatureSet {
     since = "0.16.0",
     note = "Use SchnorrSignature::sign_message instead. This method will be removed in v1.0.0"
 )]
-pub fn sign<D: Digest>(
+pub fn sign<D: Digest, R: RngCore + CryptoRng>(
     private_key: &RistrettoSecretKey,
     message: &[u8],
+    rng: &mut R,
 ) -> Result<SignatureSet, SchnorrSignatureError> {
-    let mut rng = rand::thread_rng();
-    let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut rng);
+    let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(rng);
     let message = D::new()
         .chain_update(public_nonce.as_bytes())
         .chain_update(message)

--- a/src/signatures/commitment_and_public_key_signature.rs
+++ b/src/signatures/commitment_and_public_key_signature.rs
@@ -1,27 +1,29 @@
 // Copyright 2021. The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::{
+use alloc::vec::Vec;
+use core::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     ops::{Add, Mul},
 };
 
-use rand::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
+use rand_core::{CryptoRng, RngCore};
+use snafu::prelude::*;
 use tari_utilities::ByteArray;
-use thiserror::Error;
 
 use crate::{
+    alloc::borrow::ToOwned,
     commitment::{HomomorphicCommitment, HomomorphicCommitmentFactory},
     keys::{PublicKey, SecretKey},
 };
 
 /// An error when creating a commitment signature
-#[derive(Clone, Debug, Error, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Snafu, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum CommitmentAndPublicKeySignatureError {
-    #[error("An invalid challenge was provided")]
+    #[snafu(display("An invalid challenge was provided"))]
     InvalidChallenge,
 }
 
@@ -53,8 +55,9 @@ pub enum CommitmentAndPublicKeySignatureError {
 /// The use of efficient multiscalar multiplication algorithms may also be useful for efficiency.
 /// The use of precomputation tables for `G` and `H` may also be useful for efficiency.
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CommitmentAndPublicKeySignature<P, K> {
     ephemeral_commitment: HomomorphicCommitment<P>,
     ephemeral_pubkey: P,

--- a/src/signatures/commitment_signature.rs
+++ b/src/signatures/commitment_signature.rs
@@ -1,15 +1,15 @@
 // Copyright 2021. The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::{
+use alloc::vec::Vec;
+use core::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     ops::{Add, Mul},
 };
 
-use serde::{Deserialize, Serialize};
+use snafu::prelude::*;
 use tari_utilities::{ByteArray, ByteArrayError};
-use thiserror::Error;
 
 use crate::{
     commitment::{HomomorphicCommitment, HomomorphicCommitmentFactory},
@@ -17,10 +17,11 @@ use crate::{
 };
 
 /// An error when creating a commitment signature
-#[derive(Clone, Debug, Error, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Snafu, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum CommitmentSignatureError {
-    #[error("An invalid challenge was provided")]
+    #[snafu(display("An invalid challenge was provided"))]
     InvalidChallenge,
 }
 
@@ -46,8 +47,9 @@ pub enum CommitmentSignatureError {
 ///   S =? R + e.C           ... (final verification)
 
 #[allow(non_snake_case)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshDeserialize, borsh::BorshSerialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CommitmentSignature<P, K> {
     public_nonce: HomomorphicCommitment<P>,
     u: K,

--- a/src/signatures/schnorr.rs
+++ b/src/signatures/schnorr.rs
@@ -5,7 +5,7 @@
 //! This module defines generic traits for handling the digital signature operations, agnostic
 //! of the underlying elliptic curve implementation
 
-use std::{
+use core::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     marker::PhantomData,
@@ -14,9 +14,9 @@ use std::{
 
 use blake2::Blake2b;
 use digest::{consts::U32, Digest};
-use serde::{Deserialize, Serialize};
+use rand_core::{CryptoRng, RngCore};
+use snafu::prelude::*;
 use tari_utilities::ByteArray;
-use thiserror::Error;
 
 use crate::{
     hash_domain,
@@ -28,10 +28,11 @@ use crate::{
 hash_domain!(SchnorrSigChallenge, "com.tari.schnorr_signature", 1);
 
 /// An error occurred during construction of a SchnorrSignature
-#[derive(Clone, Debug, Error, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Snafu, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub enum SchnorrSignatureError {
-    #[error("An invalid challenge was provided")]
+    #[snafu(display("An invalid challenge was provided"))]
     InvalidChallenge,
 }
 
@@ -42,12 +43,13 @@ pub enum SchnorrSignatureError {
 ///
 /// More details on Schnorr signatures can be found at [TLU](https://tlu.tarilabs.com/cryptography/introduction-schnorr-signatures).
 #[allow(non_snake_case)]
-#[derive(Copy, Debug, Clone, Serialize, Deserialize)]
+#[derive(Copy, Debug, Clone)]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SchnorrSignature<P, K, H = SchnorrSigChallenge> {
     public_nonce: P,
     signature: K,
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     _phantom: PhantomData<H>,
 }
 
@@ -121,12 +123,16 @@ where
     ///
     /// it is possible to customise the challenge by using [`construct_domain_separated_challenge`] and [`sign_raw`]
     /// yourself, or even use [`sign_raw`] using a completely custom challenge.
-    pub fn sign_message<'a, B>(secret: &'a K, message: B) -> Result<Self, SchnorrSignatureError>
+    pub fn sign_message<'a, B, R: RngCore + CryptoRng>(
+        secret: &'a K,
+        message: B,
+        rng: &mut R,
+    ) -> Result<Self, SchnorrSignatureError>
     where
         K: Add<Output = K> + Mul<&'a K, Output = K>,
         B: AsRef<[u8]>,
     {
-        let nonce = K::random(&mut rand::thread_rng());
+        let nonce = K::random(rng);
         Self::sign_with_nonce_and_message(secret, nonce, message)
     }
 


### PR DESCRIPTION
This PR adds in no_std support for TariCrypto. 
The following changes where made to enable this:
- thiserror was swapped out for Snafu as thiserror does not support no_std while snafu does.
- use std::  was changed to use core::
- make all dependencies default-features = false
- make BulletProofPlus an optional feature
- make serde an optional feature
- Make precomputed_tables optional as they require large internal memory
- remove lazy_static as a dependency (replaced by one-cell)
- changed sign message to use supplied RNG, and not thread_local internally