### PR TITLE
tests: add fuzzing of secret key

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tari_crypto-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.tari_crypto]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "keys"
+path = "fuzz_targets/keys.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/keys.rs
+++ b/fuzz/fuzz_targets/keys.rs
@@ -1,0 +1,24 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_crypto::tari_utilities::ByteArray;
+
+fuzz_target!(|data: &[u8]| {
+
+    if data.len() < 32 {
+        return;
+    }
+    match RistrettoSecretKey::from_bytes(&data[0..32]) {
+        Ok(r) => {
+            // WIP: this should fail because we do a mod.
+            // We should implement from_bytes_canonical
+            assert_eq!(&r.to_vec(), &data[0..32]);
+        }
+        Err(e) => {
+            // This is unlikely to fail
+            todo!()
+        }
+    }
+
+});

--- a/fuzz/fuzz_targets/keys.rs
+++ b/fuzz/fuzz_targets/keys.rs
@@ -2,6 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_crypto::tari_utilities::ByteArray;
 
 fuzz_target!(|data: &[u8]| {
@@ -13,7 +14,7 @@ fuzz_target!(|data: &[u8]| {
         Ok(r) => {
             // WIP: this should fail because we do a mod.
             // We should implement from_bytes_canonical
-            assert_eq!(&r.to_vec(), &data[0..32]);
+            //assert_eq!(&r.to_vec(), &data[0..32]);
         }
         Err(e) => {
             // This is unlikely to fail
@@ -21,4 +22,13 @@ fuzz_target!(|data: &[u8]| {
         }
     }
 
+    match RistrettoPublicKey::from_bytes(&data[0..32]) {
+        Ok(r) => {
+            assert_eq!(&r.to_vec(), &data[0..32]);
+        }
+        Err(e) => {
+            // There are many ways this can fail
+            // dbg!(&data[0..32]);
+        }
+    }
 });


### PR DESCRIPTION
WIP: Added fuzzing to RistrettoSecretKey, this is difficult to test a round trip to and from bytes because the from_bytes implementation allows field values higher than the group order. I'm going to leave this in draft until we have merged the other PR that implements `from_canonical_bytes`