### PR TITLE
ci: more jobs for precomputed_tables

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -47,6 +47,11 @@ jobs:
         with:
           command: check
           args: --release --no-default-features
+      - name: Cargo check precomputed
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --release --no-default-features --features precomputed_tables
       # This check here is to ensure that it builds for no-std rust targets
       - name: Cargo check for no-std
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,21 @@ jobs:
         with:
           command: test
           args: --all-features
+      - name: test/release default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
       - name: test/release features
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --all-features
+          args: --release --no-default-features
+      - name: test/release features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features --features precomputed_tables
       - name: docs build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Since the features for precomputed_tables include different code when the feature is enabled or not, it is not sufficient to test with --all-features. In this PR I've tried to add jobs for running CI to find problems with code that is excluded when the feature is present or not