### PR TITLE
ci: update CI actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,7 +7,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check_licence.yml
+++ b/.github/workflows/check_licence.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: install ripgrep
         run: |
           wget https://github.com/BurntSushi/ripgrep/releases/download/13.0.0/ripgrep_13.0.0_amd64.deb

--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -1,4 +1,4 @@
-name: Clippy and FMT
+name: Formatting, lints, and code checks
 on: [push, pull_request]
 
 jobs:
@@ -6,52 +6,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Install components
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           components: clippy, rustfmt
           toolchain: nightly
-          override: true
       - name: Toolchain thumbv8m.main-none-eabi
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          target: thumbv8m.main-none-eabi
-          override: true
+          targets: thumbv8m.main-none-eabi
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          toolchain: nightly
-          args: --all -- --check
-      - name: Install cargo-lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-lints
-      - name: Clippy lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: lints
-          toolchain: nightly
-          args: clippy --all-targets --all-features
-      - name: Cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --release --all-targets
-      - name: Cargo check no default
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --release --no-default-features
+        run: cargo +nightly fmt --all -- --check
+      - name: Install linter
+        run: cargo install cargo-lints
+      - name: Run linter
+        run: cargo +nightly lints clippy --all-targets --all-features
+      - name: Check code
+        run: cargo +stable check --release --all-targets
+      - name: Check code (no default features)
+        run: cargo +stable check --release --no-default-features
       # This check here is to ensure that it builds for no-std rust targets
-      - name: Cargo check for no-std
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          toolchain: nightly
-          args: --no-default-features --target=thumbv8m.main-none-eabi -Zavoid-dev-deps
-
+      - name: Check code (no-std)
+        run: cargo +nightly check --no-default-features --target=thumbv8m.main-none-eabi -Zavoid-dev-deps
+      - name: Check benchmarks
+        run: cargo +nightly check --benches

--- a/.github/workflows/source-cov.yml
+++ b/.github/workflows/source-cov.yml
@@ -10,16 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install -y jq lcov
       - name: Download Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
-          override: true
           components: llvm-tools-preview
       - name: Install requirements for code coverage
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,40 +11,19 @@ jobs:
         rust:
           - stable
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install components
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
+          toolchain: stable
       - name: test/debug
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo +stable test
       - name: test/release
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
+        run: cargo +stable test --release
       - name: test/debug features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo +stable test --all-features
       - name: test/release features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --all-features
-      - name: docs build
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all-features
-      - name: bench
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --benches
+        run: cargo +stable test --release --all-features
+      - name: Build documentation
+        run: cargo doc --all-features --no-deps


### PR DESCRIPTION
This PR updates CI actions.

Because the `actions-rs` project is [unmaintained](https://github.com/actions-rs/toolchain/issues/216), this is replaced with the [maintained](https://github.com/dtolnay/rust-toolchain) `dtolnay/rust-toolchain` action. The outdated `checkout` action version is [updated](https://github.com/actions/checkout/releases/tag/v4.0.0). Documentation builds are [flagged](https://doc.rust-lang.org/cargo/commands/cargo-doc.html#documentation-options) to avoid dependencies, which aren't needed.