### PR TITLE
test: expand and clean up lints

### DIFF
--- a/lints.toml
+++ b/lints.toml
@@ -1,41 +1,33 @@
 deny = [
     # Prevent spelling mistakes in lints
     'unknown_lints',
-    # clippy groups:
-    'clippy::correctness',
-    # All clippy allows must have a reason
-    # TODO: enable lint-reasons feature
-    #    'clippy::allow_attributes_without_reason',
-    # Docs
+
+    # Use the default groups:
+    # correctness, suspicious, style, complexity, perf
+    'clippy::all',
+    
+    # Require documentation
      'missing_docs',
-    #    'clippy::missing_errors_doc',
-    #    'clippy::missing_safety_doc',
-    #    'clippy::missing_panics_doc',
 
     # Common mistakes
-    'clippy::await_holding_lock',
     'unused_variables',
     'unused_imports',
     'dead_code',
     'unused_extern_crates',
     'unused_must_use',
     'unreachable_patterns',
+    'let_underscore_drop',
+
     'clippy::cloned_instead_of_copied',
     'clippy::create_dir',
     'clippy::dbg_macro',
     'clippy::else_if_without_else',
     'clippy::enum_glob_use',
     'clippy::inline_always',
-    'let_underscore_drop',
-    'clippy::let_unit_value',
     'clippy::match_on_vec_items',
     'clippy::match_wild_err_arm',
-    # In crypto code, it is fairly common to have similar names e.g. `owner_pk` and `owner_k`
-    # 'clippy::similar_names',
-    'clippy::needless_borrow',
 
-    # style
-    'clippy::style',
+    # Style preferences
     'clippy::explicit_into_iter_loop',
     'clippy::explicit_iter_loop',
     'clippy::if_not_else',
@@ -46,7 +38,7 @@ deny = [
     'clippy::too_many_lines',
     'clippy::trivially_copy_pass_by_ref',
 
-    # casting mistakes
+    # Casting mistakes
     'clippy::cast_lossless',
     'clippy::cast_possible_truncation',
     'clippy::cast_possible_wrap',


### PR DESCRIPTION
There are currently several `clippy` [groups](https://github.com/rust-lang/rust-clippy#clippy) that are useful, but are not included in `lints.toml`. This PR adds the default `clippy::all` group to the deny list, and cleans up some individual lints that are made redundant by this change. No code changes are needed as a result of this.