### PR TITLE
fix!: improve zeroizing support

### DIFF
--- a/src/extended_range_proof.rs
+++ b/src/extended_range_proof.rs
@@ -5,6 +5,8 @@
 
 use std::{string::ToString, vec::Vec};
 
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
 use crate::{
     commitment::{ExtensionDegree, HomomorphicCommitment},
     errors::RangeProofError,
@@ -99,7 +101,7 @@ pub trait ExtendedRangeProofService {
 
 /// Extended blinding factor vector used as part of the witness to construct an extended proof, or rewind data
 /// extracted from a range proof containing the mask (e.g. blinding factor vector).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct ExtendedMask<K>
 where K: SecretKey
 {
@@ -200,7 +202,7 @@ where PK: PublicKey
 
 /// The extended witness contains the extended mask (blinding factor vector), value and a minimum value
 /// promise; this will be used to construct the extended range proof
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct ExtendedWitness<K>
 where K: SecretKey
 {

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -65,7 +65,7 @@ impl borsh::BorshSerialize for RistrettoSecretKey {
 impl borsh::BorshDeserialize for RistrettoSecretKey {
     fn deserialize_reader<R>(reader: &mut R) -> Result<Self, borsh::maybestd::io::Error>
     where R: borsh::maybestd::io::Read {
-        let bytes: Vec<u8> = borsh::BorshDeserialize::deserialize_reader(reader)?;
+        let bytes: Zeroizing<Vec<u8>> = Zeroizing::new(borsh::BorshDeserialize::deserialize_reader(reader)?);
         Self::from_canonical_bytes(bytes.as_slice())
             .map_err(|e| borsh::maybestd::io::Error::new(borsh::maybestd::io::ErrorKind::InvalidInput, e.to_string()))
     }
@@ -230,12 +230,6 @@ define_mul_variants!(
 impl From<u64> for RistrettoSecretKey {
     fn from(v: u64) -> Self {
         let s = Scalar::from(v);
-        RistrettoSecretKey(s)
-    }
-}
-
-impl From<Scalar> for RistrettoSecretKey {
-    fn from(s: Scalar) -> Self {
         RistrettoSecretKey(s)
     }
 }


### PR DESCRIPTION
This adds `Zeroize` and `ZeroizeOnDrop` to `ExtendedMask` and `ExtendedWitness` for improved memory handling functionality. It restricts the visibility of an internal commitment constructor and adds zeroizing to temporary secret values. It updates secret key deserialization to add zeroizing to a temporary byte array. Finally, it removes a secret key constructor.

Supersedes #204.

BREAKING CHANGE: Changes the commitment and secret key APIs.