### PR TITLE
feat: update curve library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 tari_utilities = { version = "0.7", default-features = false, features = ["zero"] }
 blake2 = { version = "0.10", default-features = false  }
 borsh = { version = "1.2" , optional = true , default-features = false, features = ["derive"]}
-bulletproofs_plus = { package = "tari_bulletproofs_plus", version = "0.3", optional = true }
-curve25519-dalek = { package = "tari-curve25519-dalek",  version = "4.0.3", default-features = false, features = [ "alloc", "rand_core", "precomputed-tables", "zeroize"] }
+bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/AaronFeickert/bulletproofs-plus", branch = "curve-library-update", optional = true }
+curve25519-dalek = { git = "https://github.com/AaronFeickert/curve25519-dalek", branch = "TEST-rebase", default-features = false, features = [ "alloc", "rand_core", "precomputed-tables", "zeroize"] }
 digest = { version = "0.10", default-features = false }
 log = { version = "0.4" , default-features = false}
 once_cell = { version = "1.8", default-features = false, features = ["critical-section"] }


### PR DESCRIPTION
Updates the curve library fork to a version that is current with upstream.

Also updates the Bulletproofs+ version and makes a few fixes required due to this change.

Marked as draft until the dependency branches are merged.