### PR TITLE
fix: add opt-in std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,20 @@ rand = { version = "0.8" }
 
 [features]
 default = ["bulletproofs_plus", "serde", "precomputed_tables", "borsh"]
+std = [
+    "blake2/std",
+    "borsh?/std",
+    "digest/std",
+    "log/std",
+    "once_cell/std",
+    "rand_chacha/std",
+    "rand_core/std",
+    "serde?/std",
+    "sha3/std",
+    "snafu/std",
+    "tari_utilities/std",
+    "zeroize/std",
+]
 precomputed_tables = []
 
 [lib]


### PR DESCRIPTION
There are cases where std is needed (barring workarounds). E.g. errors implementing std::error::Error. 

This PR adds the ability to opt-in to the stdlib.