### PR TITLE
fix: reject identity keys and commitments in signatures

### DIFF
--- a/src/ristretto/ristretto_sig.rs
+++ b/src/ristretto/ristretto_sig.rs
@@ -263,4 +263,21 @@ mod test {
         assert!(!sig.verify(&P, "Qs are things that happen to other people"));
         assert!(!sig.verify(&(&P + &P), "Queues are things that happen to other people"));
     }
+
+    #[test]
+    fn zero_public_key() {
+        let mut rng = rand::thread_rng();
+
+        // Generate a zero key
+        let secret_key = RistrettoSecretKey::default();
+        let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
+        assert_eq!(public_key, RistrettoPublicKey::default());
+
+        // Sign a message with the zero key
+        let message = "A secret message";
+        let sig = RistrettoSchnorr::sign(&secret_key, message, &mut rng).unwrap();
+
+        // The signature should fail to verify
+        assert!(!sig.verify(&public_key, message,));
+    }
 }

--- a/src/signatures/commitment_and_public_key_signature.rs
+++ b/src/signatures/commitment_and_public_key_signature.rs
@@ -176,6 +176,11 @@ where
         C: HomomorphicCommitmentFactory<P = P>,
         R: RngCore + CryptoRng,
     {
+        // Reject a zero commitment and public key
+        if commitment.as_public_key() == &P::default() || pubkey == &P::default() {
+            return false;
+        }
+
         // The challenge cannot be zero
         if *challenge == K::default() {
             return false;

--- a/src/signatures/commitment_signature.rs
+++ b/src/signatures/commitment_signature.rs
@@ -136,6 +136,11 @@ where
         for<'b> &'b HomomorphicCommitment<P>: Add<&'b HomomorphicCommitment<P>, Output = HomomorphicCommitment<P>>,
         C: HomomorphicCommitmentFactory<P = P>,
     {
+        // Reject a zero commitment
+        if public_commitment.as_public_key() == &P::default() {
+            return false;
+        }
+
         // v*H + u*G
         let lhs = self.calc_signature_verifier(factory);
         // R + e.C

--- a/src/signatures/schnorr.rs
+++ b/src/signatures/schnorr.rs
@@ -24,7 +24,8 @@ use crate::{
     keys::{PublicKey, SecretKey},
 };
 
-// Define the hashing domain for Schnorr signatures
+// Define a default hashing domain for Schnorr signatures
+// You almost certainly want to define your own that is specific to signature context!
 hash_domain!(SchnorrSigChallenge, "com.tari.schnorr_signature", 1);
 
 /// An error occurred during construction of a SchnorrSignature
@@ -231,6 +232,11 @@ where
         for<'b> &'b K: Mul<&'a P, Output = P>,
         for<'b> &'b P: Add<P, Output = P>,
     {
+        // Reject a zero key
+        if public_key == &P::default() {
+            return false;
+        }
+
         let lhs = self.calc_signature_verifier();
         let rhs = &self.public_nonce + challenge * public_key;
         // Implementors should make this a constant time comparison


### PR DESCRIPTION
Signature verification currently allows identity elements:
- `SchnorrSignature` allows an identity public key
- `CommitmentSignature` allows an identity commitment
- `CommitmentAndPublicKeySignature` allows both

This doesn't strictly break soundness, but does remove message binding. While it shouldn't be problematic for unforgeability, it's a case that shouldn't arise from an honest signer and is easy to check for.

This PR fails signature verification if such an identity element is provided, and adds tests for each case. It does _not_ return an error if the corresponding identity elements are provided by the signer, since this precludes useful partial signature operations.