### PR TITLE
feat: add constant-time trait bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rand_core = { version = "0.6" , default-features = false}
 serde = { version = "1.0", optional = true }
 sha3 = { version = "0.10", default-features = false  }
 snafu = { version = "0.7", default-features = false}
+subtle = { version = "2.5.0", default-features = false }
 zeroize = {version = "1" , default-features = false}
 
 [dev-dependencies]
@@ -48,6 +49,7 @@ std = [
     "serde?/std",
     "sha3/std",
     "snafu/std",
+    "subtle/std",
     "tari_utilities/std",
     "zeroize/std",
 ]

--- a/src/dhke.rs
+++ b/src/dhke.rs
@@ -11,18 +11,19 @@
 
 use core::ops::Mul;
 
+use subtle::{Choice, ConstantTimeEq};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::keys::PublicKey;
 
 /// The result of a Diffie-Hellman key exchange
-#[derive(Zeroize, ZeroizeOnDrop)]
+#[derive(PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct DiffieHellmanSharedSecret<P>(P)
-where P: Zeroize;
+where P: PublicKey;
 
 impl<P> DiffieHellmanSharedSecret<P>
 where
-    P: PublicKey + Zeroize,
+    P: PublicKey,
     for<'a> &'a <P as PublicKey>::K: Mul<&'a P, Output = P>,
 {
     /// Perform a Diffie-Hellman key exchange
@@ -33,6 +34,14 @@ where
     /// Get the shared secret as a byte array
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
+    }
+}
+
+impl<P> ConstantTimeEq for DiffieHellmanSharedSecret<P>
+where P: PublicKey
+{
+    fn ct_eq(&self, other: &DiffieHellmanSharedSecret<P>) -> Choice {
+        self.0.ct_eq(&other.0)
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -9,6 +9,7 @@
 use core::ops::Add;
 
 use rand_core::{CryptoRng, RngCore};
+use subtle::ConstantTimeEq;
 use tari_utilities::{ByteArray, ByteArrayError};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -27,7 +28,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 /// let p = RistrettoPublicKey::from_secret_key(&k);
 /// ```
 pub trait SecretKey:
-    ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default + Zeroize + ZeroizeOnDrop
+    ByteArray + Clone + ConstantTimeEq + PartialEq + Eq + Add<Output = Self> + Default + Zeroize + ZeroizeOnDrop
 {
     /// The length of the byte encoding of a key, in bytes
     const KEY_LEN: usize;
@@ -54,7 +55,9 @@ pub trait SecretKey:
 /// implementations need to implement this trait for them to be used in Tari.
 ///
 /// See [SecretKey](trait.SecretKey.html) for an example.
-pub trait PublicKey: ByteArray + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Zeroize {
+pub trait PublicKey:
+    ByteArray + ConstantTimeEq + PartialEq + Eq + Add<Output = Self> + Clone + PartialOrd + Ord + Default + Zeroize
+{
     /// The length of the byte encoding of a key, in bytes
     const KEY_LEN: usize;
 


### PR DESCRIPTION
Currently, the only implementation of the `SecretKey` and `PublicKey` traits is for Ristretto, where both [scalars](https://github.com/dalek-cryptography/curve25519-dalek/blob/ba737a379071191158bacfa6d138f6249b12fc09/curve25519-dalek/src/scalar.rs#L296-L300) and [group elements](https://github.com/dalek-cryptography/curve25519-dalek/blob/ba737a379071191158bacfa6d138f6249b12fc09/curve25519-dalek/src/ristretto.rs#L822-L826) use constant-time equality in their underlying `PartialEq` implementations, and which support the `ConstantTimeEq` trait.

This PR does what it can to encourage the use of constant-time equality for keys by doing a few things.

First, it requires that any types implementing `SecretKey` or `PublicKey` also implement `ConstantTimeEq`. Unfortunately, this doesn't guarantee that their `PartialEq` implementation defaults to this, and it doesn't appear possible to enforce this at the trait level.

It also sets a good example by manually implementing `PartialEq` on the Ristretto key types to use their `ConstantTimeEq` implementations. This isn't strictly necessary, but hopefully helps to indicate best practice. It also implements `ConstantTimeEq` directly as required by the new trait bounds.

Finally, it implements `ConstantTimeEq` for `DiffieHellmanSharedSecret` using the new trait bound, and removes a redundant `Zeroize` trait bound.

Note that this doesn't actually change the current implementations' behavior, and therefore incurs no performance hit.

Closes #139.