### PR TITLE
ci: fix lint error

### DIFF
--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -156,7 +156,7 @@ impl<P: PublicKey> Hash for HomomorphicCommitment<P> {
 
 impl<P: PublicKey> PartialEq for HomomorphicCommitment<P> {
     fn eq(&self, other: &Self) -> bool {
-        self.as_public_key().eq(other.as_public_key())
+        self.as_public_key() == other.as_public_key()
     }
 }
 


### PR DESCRIPTION
Nightly `clippy` incorrectly reports that the commitment `PartialEq` [implementation](https://github.com/tari-project/tari-crypto/blob/017bb2cde069fc8a1b1a6014f339e59dc7fd6ca7/src/commitment.rs#L157-L161) recurses. Changing the syntax to use `==` seems to fix this and does the same thing.

Closes #220.