### PR TITLE
ci: pin nightly toolchain

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -1,6 +1,9 @@
 name: Formatting, lints, and code checks
 on: [push, pull_request]
 
+env:
+  nightly: nightly-2024-02-01
+
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
@@ -11,24 +14,24 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: clippy, rustfmt
-          toolchain: nightly
+          toolchain: ${{ env.nightly }}
       - name: Toolchain thumbv8m.main-none-eabi
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: ${{ env.nightly }}
           targets: thumbv8m.main-none-eabi
       - name: Check formatting
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +${{ env.nightly }} fmt --all -- --check
       - name: Install linter
         run: cargo install cargo-lints
       - name: Run linter
-        run: cargo +nightly lints clippy --all-targets --all-features
+        run: cargo +${{ env.nightly }} lints clippy --all-targets --all-features
       - name: Check code
         run: cargo +stable check --release --all-targets
       - name: Check code (no default features)
         run: cargo +stable check --release --no-default-features
       # This check here is to ensure that it builds for no-std rust targets
       - name: Check code (no-std)
-        run: cargo +nightly check --no-default-features --target=thumbv8m.main-none-eabi -Zavoid-dev-deps
+        run: cargo +${{ env.nightly }} check --no-default-features --target=thumbv8m.main-none-eabi -Zavoid-dev-deps
       - name: Check benchmarks
-        run: cargo +nightly check --benches
+        run: cargo +${{ env.nightly }} check --benches


### PR DESCRIPTION
Sadly, nightly CI is borked due to an [upstream issue](https://github.com/dalek-cryptography/curve25519-dalek/issues/618) identified with a recent nightly release.

This PR pins the nightly toolchain at a working version.