### PR TITLE
ci: move to stable toolchain

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -1,9 +1,6 @@
 name: Formatting, lints, and code checks
 on: [push, pull_request]
 
-env:
-  nightly: nightly-2024-02-01
-
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
@@ -14,24 +11,24 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: clippy, rustfmt
-          toolchain: ${{ env.nightly }}
-      - name: Toolchain thumbv8m.main-none-eabi
+          toolchain: nightly
+      - name: Toolchain wasm32-unknown-unknown
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.nightly }}
-          targets: thumbv8m.main-none-eabi
+          toolchain: stable
+          targets: wasm32-unknown-unknown
       - name: Check formatting
-        run: cargo +${{ env.nightly }} fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
       - name: Install linter
         run: cargo install cargo-lints
       - name: Run linter
-        run: cargo +${{ env.nightly }} lints clippy --all-targets --all-features
+        run: cargo +stable lints clippy --all-targets --all-features
       - name: Check code
         run: cargo +stable check --release --all-targets
       - name: Check code (no default features)
         run: cargo +stable check --release --no-default-features
       # This check here is to ensure that it builds for no-std rust targets
       - name: Check code (no-std)
-        run: cargo +${{ env.nightly }} check --no-default-features --target=thumbv8m.main-none-eabi -Zavoid-dev-deps
+        run: cargo +stable check --no-default-features --target=wasm32-unknown-unknown
       - name: Check benchmarks
-        run: cargo +${{ env.nightly }} check --benches
+        run: cargo +stable check --benches

--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -12,11 +12,11 @@ jobs:
         with:
           components: clippy, rustfmt
           toolchain: nightly
-      - name: Toolchain wasm32-unknown-unknown
+      - name: Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          targets: wasm32-unknown-unknown
+          targets: thumbv8m.main-none-eabi
       - name: Check formatting
         run: cargo +nightly fmt --all -- --check
       - name: Install linter
@@ -29,6 +29,6 @@ jobs:
         run: cargo +stable check --release --no-default-features
       # This check here is to ensure that it builds for no-std rust targets
       - name: Check code (no-std)
-        run: cargo +stable check --no-default-features --target=wasm32-unknown-unknown
+        run: cargo +stable check --no-default-features --target=thumbv8m.main-none-eabi
       - name: Check benchmarks
         run: cargo +stable check --benches

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,12 @@ subtle = { version = "2.5.0", default-features = false }
 zeroize = {version = "1" , default-features = false}
 
 [dev-dependencies]
-tari_utilities = { version = "0.7", features = ["std"] }
-serde = { version = "1.0"}
+tari_utilities = { version = "0.7" }
+serde = { version = "1.0" }
 bincode = { version = "1.1" }
 criterion = { version = "0.5", default-features = false }
 sha2 = { version = "0.10" }
-rand = { version = "0.8" }
-
+rand_chacha = { version = "0.3.1", default-features = false }
 
 [features]
 default = ["bulletproofs_plus", "serde", "precomputed_tables", "borsh"]
@@ -54,6 +53,8 @@ std = [
     "zeroize/std",
 ]
 precomputed_tables = []
+# This is so doctests can work with `OsRng`
+rand = ['rand_core/getrandom']
 
 [lib]
 # Disable benchmarks to allow Criterion to take over

--- a/benches/commitment.rs
+++ b/benches/commitment.rs
@@ -4,7 +4,8 @@
 use std::time::Duration;
 
 use criterion::{criterion_group, Criterion};
-use rand::thread_rng;
+use rand_chacha::ChaCha12Rng;
+use rand_core::SeedableRng;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::SecretKey,
@@ -13,7 +14,7 @@ use tari_crypto::{
 
 pub fn commit_default(c: &mut Criterion) {
     let factory = PedersenCommitmentFactory::default();
-    let mut rng = thread_rng();
+    let mut rng = ChaCha12Rng::seed_from_u64(12345);
 
     c.bench_function("commit_default key pair", |b| {
         // Commitment value and mask

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -20,12 +20,15 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 ///
 /// Assuming there is a Ristretto implementation,
 /// ```edition2018
+/// # #[cfg(feature = "rand")]
+/// # {
 /// # use tari_crypto::ristretto::{ RistrettoSecretKey, RistrettoPublicKey };
 /// # use tari_crypto::keys::{ SecretKey, PublicKey };
-/// # use rand;
-/// let mut rng = rand::thread_rng();
+/// # use rand_core::OsRng;
+/// let mut rng = OsRng;
 /// let k = RistrettoSecretKey::random(&mut rng);
 /// let p = RistrettoPublicKey::from_secret_key(&k);
+/// # }
 /// ```
 pub trait SecretKey:
     ByteArray + Clone + ConstantTimeEq + PartialEq + Eq + Add<Output = Self> + Default + Zeroize + ZeroizeOnDrop

--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -95,6 +95,8 @@ mod test {
     };
 
     use curve25519_dalek::scalar::Scalar;
+    use rand_chacha::ChaCha12Rng;
+    use rand_core::SeedableRng;
 
     use super::*;
     use crate::{
@@ -131,7 +133,7 @@ mod test {
     fn check_open() {
         let factory = PedersenCommitmentFactory::default();
         let H = *ristretto_pedersen_h();
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         for _ in 0..100 {
             let v = RistrettoSecretKey::random(&mut rng);
             let k = RistrettoSecretKey::random(&mut rng);
@@ -154,7 +156,7 @@ mod test {
     /// `open(k1+k2, v1+v2)` is true for _C_
     #[test]
     fn check_homomorphism() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         for _ in 0..100 {
             let v1 = RistrettoSecretKey::random(&mut rng);
             let v2 = RistrettoSecretKey::random(&mut rng);
@@ -182,7 +184,7 @@ mod test {
     /// `open(k1+k2, v1)` is true for _C_
     #[test]
     fn check_homomorphism_with_public_key() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         // Left-hand side
         let v1 = RistrettoSecretKey::random(&mut rng);
         let k1 = RistrettoSecretKey::random(&mut rng);
@@ -205,7 +207,7 @@ mod test {
     /// `open(sum(k_j), sum(v_j))` is true for `sum(C_j)`
     #[test]
     fn sum_commitment_vector() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let mut v_sum = RistrettoSecretKey::default();
         let mut k_sum = RistrettoSecretKey::default();
         let zero = RistrettoSecretKey::default();
@@ -228,7 +230,7 @@ mod test {
     #[test]
     fn serialize_deserialize() {
         use tari_utilities::message_format::MessageFormat;
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let factory = PedersenCommitmentFactory::default();
         let k = RistrettoSecretKey::random(&mut rng);
         let c = factory.commit_value(&k, 420);

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -211,7 +211,8 @@ mod test {
     };
 
     use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar, traits::MultiscalarMul};
-    use rand::rngs::ThreadRng;
+    use rand_chacha::ChaCha12Rng;
+    use rand_core::SeedableRng;
 
     use crate::{
         commitment::{
@@ -301,7 +302,7 @@ mod test {
     #[allow(non_snake_case)]
     fn check_open_both_traits() {
         let H = *ristretto_pedersen_h();
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         for extension_degree in EXTENSION_DEGREE {
             let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
             for _ in 0..25 {
@@ -348,7 +349,7 @@ mod test {
     /// `open(k1_i+k2_i, v1+v2)` is true for _C_
     #[test]
     fn check_homomorphism_both_traits() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         for extension_degree in EXTENSION_DEGREE {
             for _ in 0..25 {
                 let v1 = RistrettoSecretKey::random(&mut rng);
@@ -399,7 +400,7 @@ mod test {
     /// `open(k1+k2, v1)` is true for _C_
     #[test]
     fn check_homomorphism_with_public_key_singular() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         // Left-hand side
         let v1 = RistrettoSecretKey::random(&mut rng);
         let k1 = RistrettoSecretKey::random(&mut rng);
@@ -414,7 +415,7 @@ mod test {
         assert!(factory.open(&(&k1 + &k2), &v1, &c2));
     }
 
-    fn scalar_random_not_zero(rng: &mut ThreadRng) -> Scalar {
+    fn scalar_random_not_zero(rng: &mut ChaCha12Rng) -> Scalar {
         loop {
             let value = Scalar::random(rng);
             if value != Scalar::ZERO {
@@ -427,7 +428,7 @@ mod test {
     fn random_keypair_extended(
         factory: &ExtendedPedersenCommitmentFactory,
         extension_degree: ExtensionDegree,
-        rng: &mut ThreadRng,
+        rng: &mut ChaCha12Rng,
     ) -> (RistrettoSecretKey, RistrettoPublicKey) {
         let mut k_vec = vec![scalar_random_not_zero(rng)];
         if extension_degree != ExtensionDegree::DefaultPedersen {
@@ -448,7 +449,7 @@ mod test {
     /// Note: Homomorphism with public key only holds for extended commitments with`ExtensionDegree::DefaultPedersen`
     #[test]
     fn check_homomorphism_with_public_key_extended() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         for extension_degree in EXTENSION_DEGREE {
             // Left-hand side
             let v1 = RistrettoSecretKey::random(&mut rng);
@@ -493,7 +494,7 @@ mod test {
     /// `open(sum(k_j), sum(v_j))` is true for `sum(C_j)`
     #[test]
     fn sum_commitment_vector_singular() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let mut v_sum = RistrettoSecretKey::default();
         let mut k_sum = RistrettoSecretKey::default();
         let zero = RistrettoSecretKey::default();
@@ -522,7 +523,7 @@ mod test {
     /// `open(sum(sum(k_i)_j), sum(v_j))` is true for `sum(C_j)`
     #[test]
     fn sum_commitment_vector_extended() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let v_zero = RistrettoSecretKey::default();
         let k_zero = vec![RistrettoSecretKey::default(); ExtensionDegree::AddFiveBasePoints as usize];
         for extension_degree in EXTENSION_DEGREE {
@@ -557,7 +558,7 @@ mod test {
         use crate::ristretto::pedersen::PedersenCommitment;
         #[test]
         fn serialize_deserialize_singular() {
-            let mut rng = rand::thread_rng();
+            let mut rng = ChaCha12Rng::seed_from_u64(12345);
             let factory = ExtendedPedersenCommitmentFactory::default();
             let k = RistrettoSecretKey::random(&mut rng);
             let c = factory.commit_value(&k, 420);
@@ -575,7 +576,7 @@ mod test {
 
         #[test]
         fn serialize_deserialize_extended() {
-            let mut rng = rand::thread_rng();
+            let mut rng = ChaCha12Rng::seed_from_u64(12345);
             for extension_degree in EXTENSION_DEGREE {
                 let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
                 let k_vec = vec![RistrettoSecretKey::random(&mut rng); extension_degree as usize];

--- a/src/ristretto/pedersen/mod.rs
+++ b/src/ristretto/pedersen/mod.rs
@@ -66,6 +66,8 @@ pub(crate) fn scalar_mul_with_pre_computation_tables(k: &Scalar, v: &Scalar) -> 
 
 #[cfg(test)]
 mod test {
+    use rand_chacha::ChaCha12Rng;
+    use rand_core::SeedableRng;
     use tari_utilities::ByteArray;
 
     use crate::{
@@ -86,7 +88,7 @@ mod test {
 
     #[test]
     fn pubkey_roundtrip() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let (_, p) = RistrettoPublicKey::random_keypair(&mut rng);
         let c = PedersenCommitment::from_public_key(&p);
         assert_eq!(c.as_public_key(), &p);
@@ -96,7 +98,7 @@ mod test {
 
     #[test]
     fn commitment_sub() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let (_, a) = RistrettoPublicKey::random_keypair(&mut rng);
         let (_, b) = RistrettoPublicKey::random_keypair(&mut rng);
         let c = &a + &b;
@@ -133,7 +135,7 @@ mod test {
     fn check_commitments_between_factories() {
         let factory_singular = PedersenCommitmentFactory::default();
         let factory_extended = ExtendedPedersenCommitmentFactory::default();
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let v = RistrettoSecretKey::random(&mut rng);
         let k = RistrettoSecretKey::random(&mut rng);
         let c_singular = factory_singular.commit(&k, &v);

--- a/src/ristretto/ristretto_com_and_pub_sig.rs
+++ b/src/ristretto/ristretto_com_and_pub_sig.rs
@@ -49,17 +49,20 @@ use crate::{
 /// verify it by calling the `verify_challenge` method:
 ///
 /// ```rust
+/// # #[cfg(feature = "rand")]
+/// # {
 /// # use tari_crypto::ristretto::*;
 /// # use tari_crypto::keys::*;
 /// # use blake2::Blake2b;
 /// # use digest::Digest;
 /// # use tari_crypto::commitment::HomomorphicCommitmentFactory;
 /// # use tari_crypto::ristretto::pedersen::*;
+/// # use rand_core::OsRng;
 /// use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
 /// use tari_utilities::hex::Hex;
 /// use digest::consts::U64;
 ///
-/// let mut rng = rand::thread_rng();
+/// let mut rng = OsRng;
 /// let a_val = RistrettoSecretKey::random(&mut rng);
 /// let x_val = RistrettoSecretKey::random(&mut rng);
 /// let y_val = RistrettoSecretKey::random(&mut rng);
@@ -75,6 +78,7 @@ use crate::{
 /// )
 /// .unwrap();
 /// assert!(sig.verify_challenge(&commitment, &pubkey, &e, &factory, &mut rng));
+/// # }
 /// ```
 pub type RistrettoComAndPubSig = CommitmentAndPublicKeySignature<RistrettoPublicKey, RistrettoSecretKey>;
 
@@ -82,7 +86,8 @@ pub type RistrettoComAndPubSig = CommitmentAndPublicKeySignature<RistrettoPublic
 mod test {
     use blake2::Blake2b;
     use digest::{consts::U64, Digest};
-    use rand_core::RngCore;
+    use rand_chacha::ChaCha12Rng;
+    use rand_core::{RngCore, SeedableRng};
     use tari_utilities::ByteArray;
 
     use crate::{
@@ -123,7 +128,7 @@ mod test {
     /// Create a signature, and then verify it. Also checks that some invalid signatures fail to verify
     #[test]
     fn sign_and_verify_message() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
 
         // Witness data
         let a_value = RistrettoSecretKey::random(&mut rng);
@@ -195,7 +200,7 @@ mod test {
     /// Create two partial signatures to the same challenge and computes if the total aggregate signature is valid.
     #[test]
     fn sign_and_verify_message_partial() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
 
         // Witness data
         let a_value = RistrettoSecretKey::random(&mut rng);
@@ -268,7 +273,7 @@ mod test {
     /// Test that commitment signatures are linear, as in a multisignature construction
     #[test]
     fn test_signature_addition() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let factory = PedersenCommitmentFactory::default();
 
         // Alice's data
@@ -363,7 +368,7 @@ mod test {
 
     #[test]
     fn zero_commitment() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let factory = PedersenCommitmentFactory::default();
 
         // Generate a zero commitment opening and a random key
@@ -396,7 +401,7 @@ mod test {
 
     #[test]
     fn zero_public_key() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let factory = PedersenCommitmentFactory::default();
 
         // Generate a random commitment opening and a zero key

--- a/src/ristretto/ristretto_com_sig.rs
+++ b/src/ristretto/ristretto_com_sig.rs
@@ -41,17 +41,20 @@ use crate::{
 /// verify it by calling the `verify_challenge` method:
 ///
 /// ```rust
+/// # #[cfg(feature = "rand")]
+/// # {
 /// # use tari_crypto::ristretto::*;
 /// # use tari_crypto::keys::*;
 /// # use digest::Digest;
 /// # use tari_crypto::commitment::HomomorphicCommitmentFactory;
 /// # use tari_crypto::ristretto::pedersen::*;
+/// # use rand_core::OsRng;
 /// use blake2::Blake2b;
 /// use digest::consts::U64;
 /// use tari_crypto::ristretto::pedersen::commitment_factory::PedersenCommitmentFactory;
 /// use tari_utilities::hex::Hex;
 ///
-/// let mut rng = rand::thread_rng();
+/// let mut rng = OsRng;
 /// let a_val = RistrettoSecretKey::random(&mut rng);
 /// let x_val = RistrettoSecretKey::random(&mut rng);
 /// let a_nonce = RistrettoSecretKey::random(&mut rng);
@@ -61,6 +64,7 @@ use crate::{
 /// let commitment = factory.commit(&x_val, &a_val);
 /// let sig = RistrettoComSig::sign(&a_val, &x_val, &a_nonce, &x_nonce, &e, &factory).unwrap();
 /// assert!(sig.verify_challenge(&commitment, &e, &factory));
+/// # }
 /// ```
 ///
 /// # Verifying signatures
@@ -107,7 +111,8 @@ pub type RistrettoComSig = CommitmentSignature<RistrettoPublicKey, RistrettoSecr
 mod test {
     use blake2::Blake2b;
     use digest::{consts::U64, Digest};
-    use rand_core::RngCore;
+    use rand_chacha::ChaCha12Rng;
+    use rand_core::{RngCore, SeedableRng};
     use tari_utilities::ByteArray;
 
     use crate::{
@@ -137,7 +142,7 @@ mod test {
     #[test]
     #[allow(non_snake_case)]
     fn sign_and_verify_message() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let a_value = RistrettoSecretKey::random(&mut rng);
         let x_value = RistrettoSecretKey::random(&mut rng);
         let factory = PedersenCommitmentFactory::default();
@@ -173,7 +178,7 @@ mod test {
     #[test]
     #[allow(non_snake_case)]
     fn test_signature_addition() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let factory = PedersenCommitmentFactory::default();
         // Alice generate some keys and nonces
         let a_value_alice = RistrettoSecretKey::random(&mut rng);
@@ -232,7 +237,7 @@ mod test {
 
     #[test]
     fn zero_commitment() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha12Rng::seed_from_u64(12345);
         let factory = PedersenCommitmentFactory::default();
 
         // Generate a zero commitment opening

--- a/src/ristretto/test_common.rs
+++ b/src/ristretto/test_common.rs
@@ -1,13 +1,18 @@
 // Copyright 2019. The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+#[cfg(test)]
 use crate::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
 };
 
+#[cfg(test)]
 pub(crate) fn get_keypair() -> (RistrettoSecretKey, RistrettoPublicKey) {
-    let mut rng = rand::thread_rng();
+    use rand_chacha::ChaCha12Rng;
+    use rand_core::SeedableRng;
+
+    let mut rng = ChaCha12Rng::seed_from_u64(12345);
     let k = RistrettoSecretKey::random(&mut rng);
     let pk = RistrettoPublicKey::from_secret_key(&k);
     (k, pk)


### PR DESCRIPTION
Currently, CI uses a mix of stable and nightly toolchains. Nightly is included primarily to support `no_std` checks, but this is only necessary due to a `rand` test dependency.

This PR makes changes to allow a move to stable across the board. To do this, it replaces the use of `rand` in all tests with a random number generator from `rand_chacha`, which has the side effect of making all tests deterministic.

However, due to a desire to keep a secure random number generator in doctests, we add an optional `rand` feature whose only role is to enable `rand_core::OsRng`. Doctests that use this are gated on this feature.

The `no_std` target has been changed to `wasm32-unknown-unknown` for easier local testing; it should still meet the goal.

Finally, note that some formatting rules are not available on stable, so we still use the latest nightly for this.