### PR TITLE
feat: add range proof batch verification blame

### DIFF
--- a/src/extended_range_proof.rs
+++ b/src/extended_range_proof.rs
@@ -83,6 +83,33 @@ pub trait ExtendedRangeProofService {
         statements: Vec<&AggregatedPublicStatement<Self::PK>>,
     ) -> Result<(), RangeProofError>;
 
+    /// Verify a batch of proofs.
+    /// If verification fails, this function performs a binary search to identify a failing proof and returns an error
+    /// containing the index of a failed proof. If it can't deserialize the proofs, or if something goes wrong
+    /// internally, returns `Err(None)`.
+    ///
+    /// If initial verification of the entire batch fails, this performs a number of subsequent batch verifications that
+    /// is logarithmic in the number of proofs. Note that this function cannot tell if a batch contains multiple
+    /// failing proofs; that's on you!
+    fn verify_batch_with_first_blame(
+        &self,
+        proofs: Vec<&Self::Proof>,
+        statements: Vec<&AggregatedPublicStatement<Self::PK>>,
+    ) -> Result<(), Option<usize>>;
+
+    /// Verify a batch of proofs.
+    /// If verification fails, this function verifies each proof in the batch separately and returns an error containing
+    /// the indexes of all failed proofs. If it can't deserialize the proofs, or if something goes wrong internally,
+    /// returns `Err(None)`.
+    ///
+    /// If initial verification of the entire batch fails, this performs a subsequent number of batch verifications that
+    /// is linear in the number of proofs.
+    fn verify_batch_with_all_blame(
+        &self,
+        proofs: Vec<&Self::Proof>,
+        statements: Vec<&AggregatedPublicStatement<Self::PK>>,
+    ) -> Result<(), Option<Vec<usize>>>;
+
     /// Recover the (unverified) extended mask for a non-aggregated proof using the provided seed-nonce.
     fn recover_extended_mask(
         &self,


### PR DESCRIPTION
It may be the case that verification of a batch of range proofs fails. When this happens, the verifier does not know which proofs in the batch are invalid.

The best approach to take depends on the use case.

If you only need to know the index of _any_ invalid proof in the batch, a linear scan is inefficient. In this case, performing a binary search on the batch is more efficient since it requires only a logarithmic number of verifications.

On the other hand, if you need to know the index of _all_ invalid proofs in the batch, and if this number may be large, a complete linear search is more efficient than repeated binary searches.

This PR adds both approaches via the `ExtendedRangeProofService` trait. The new `verify_batch_with_first_blame` function performs a binary search if batch verification fails, returning an error containing the index of the first invalid proof. The new `verify_batch_with_all_blame` function performs a complete linear search if batch verification fails, returning an error containing the indexes of all failed proofs.