### PR TITLE
chore: protect public key zeroization against updates

### DIFF
--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -343,10 +343,13 @@ impl RistrettoPublicKey {
 impl Zeroize for RistrettoPublicKey {
     /// Zeroizes both the point and (if it exists) the compressed point
     fn zeroize(&mut self) {
-        self.point.zeroize();
+        // This destructuring is to trigger a compiler error on future updates!
+        let Self { point, compressed } = self;
+
+        point.zeroize();
 
         // Need to empty the cell
-        if let Some(mut compressed) = self.compressed.take() {
+        if let Some(mut compressed) = compressed.take() {
             compressed.zeroize();
         }
     }


### PR DESCRIPTION
Ristretto public key zeroizing is done manually due to the use of `OnceCell`. I recently came across a [clever design pattern](https://github.com/BLAKE3-team/BLAKE3/blob/master/src/lib.rs#L447-L466) that uses destructuring. The idea is that future changes to the underlying struct will trigger a compiler error to ensure that the zeroization implementation is also updated.

This PR implements such a change.