### PR TITLE
feat!: remove onecell

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -27,8 +27,5 @@ jobs:
         run: cargo +stable check --release --all-targets
       - name: Check code (no default features)
         run: cargo +stable check --release --no-default-features
-      # This check here is to ensure that it builds for no-std rust targets
-      - name: Check code (no-std)
-        run: cargo +nightly check --no-default-features --target=thumbv8m.main-none-eabi -Zavoid-dev-deps
       - name: Check benchmarks
         run: cargo +nightly check --benches

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ curve25519-dalek = { version = "4", default-features = false, features = [ "allo
 digest = { version = "0.10", default-features = false }
 log = { version = "0.4" , default-features = false}
 merlin = { version = "3", default-features = false }
-once_cell = { version = "1.8", default-features = false, features = ["critical-section"] }
 rand_chacha = { version = "0.3", default-features = false }
 rand_core = { version = "0.6" , default-features = false}
 serde = { version = "1.0", optional = true }
@@ -45,7 +44,6 @@ std = [
     "digest/std",
     "log/std",
     "merlin/std",
-    "once_cell/std",
     "rand_chacha/std",
     "rand_core/std",
     "serde?/std",

--- a/src/deterministic_randomizer.rs
+++ b/src/deterministic_randomizer.rs
@@ -142,7 +142,7 @@ where
     /// Choose a random bounded 64-bit unsigned integer with exclusive upper bound
     pub fn next_bounded_u64(&mut self, upper: u64) -> Result<u64, RandomizerError> {
         // We can't get a `u128` directly from the generator
-        let x = u128::from(self.prng.next_u64()) << 64 | u128::from(self.prng.next_u64());
+        let x = (u128::from(self.prng.next_u64()) << 64) | u128::from(self.prng.next_u64());
 
         u64::try_from(x % u128::from(upper)).map_err(|_| RandomizerError)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 //! Tari-Crypto
-#![no_std]
 
 #[allow(unused_imports)]
 #[macro_use]

--- a/src/ristretto/constants.rs
+++ b/src/ristretto/constants.rs
@@ -5,8 +5,9 @@
 //! Generates a precomputation table for the first of these points for use in commitments.
 //! Tests the correctness of the NUMS construction.
 
+use std::sync::OnceLock;
+
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoBasepointTable, RistrettoPoint};
-use once_cell::sync::OnceCell;
 
 const NUMBER_NUMS_POINTS: usize = 10;
 
@@ -59,7 +60,7 @@ pub const RISTRETTO_NUMS_POINTS_COMPRESSED: [CompressedRistretto; NUMBER_NUMS_PO
 
 /// A static array of pre-generated NUMS points
 pub fn ristretto_nums_points() -> &'static [RistrettoPoint; NUMBER_NUMS_POINTS] {
-    static INSTANCE: OnceCell<[RistrettoPoint; NUMBER_NUMS_POINTS]> = OnceCell::new();
+    static INSTANCE: OnceLock<[RistrettoPoint; NUMBER_NUMS_POINTS]> = OnceLock::new();
     INSTANCE.get_or_init(|| {
         let mut arr = [RistrettoPoint::default(); NUMBER_NUMS_POINTS];
         for i in 0..NUMBER_NUMS_POINTS {
@@ -71,7 +72,7 @@ pub fn ristretto_nums_points() -> &'static [RistrettoPoint; NUMBER_NUMS_POINTS] 
 
 /// Precomputation table for the first point, which is used as the default commitment generator
 pub fn ristretto_nums_table_0() -> &'static RistrettoBasepointTable {
-    static INSTANCE: OnceCell<RistrettoBasepointTable> = OnceCell::new();
+    static INSTANCE: OnceLock<RistrettoBasepointTable> = OnceLock::new();
     INSTANCE.get_or_init(|| RistrettoBasepointTable::create(&ristretto_nums_points()[0]))
 }
 

--- a/src/ristretto/pedersen/mod.rs
+++ b/src/ristretto/pedersen/mod.rs
@@ -4,6 +4,7 @@
 //! Pederson commitments utilities
 
 use core::{borrow::Borrow, iter::Sum};
+use std::sync::OnceLock;
 
 #[cfg(feature = "precomputed_tables")]
 use curve25519_dalek::{constants::RISTRETTO_BASEPOINT_TABLE, scalar::Scalar};
@@ -11,7 +12,6 @@ use curve25519_dalek::{
     constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
     ristretto::{CompressedRistretto, RistrettoPoint},
 };
-use once_cell::sync::OnceCell;
 
 #[cfg(feature = "precomputed_tables")]
 use crate::ristretto::constants::ristretto_nums_table_0;
@@ -32,12 +32,12 @@ pub const RISTRETTO_PEDERSEN_G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
 pub const RISTRETTO_PEDERSEN_G_COMPRESSED: CompressedRistretto = RISTRETTO_BASEPOINT_COMPRESSED;
 /// The default generator on a Pedersen commitment used for the value
 pub fn ristretto_pedersen_h() -> &'static RistrettoPoint {
-    static INSTANCE: OnceCell<RistrettoPoint> = OnceCell::new();
+    static INSTANCE: OnceLock<RistrettoPoint> = OnceLock::new();
     INSTANCE.get_or_init(|| ristretto_nums_points()[0])
 }
 /// The default generator on a Pedersen commitment used for the value in a compressed form
 pub fn ristretto_pedersen_h_compressed() -> &'static CompressedRistretto {
-    static INSTANCE: OnceCell<CompressedRistretto> = OnceCell::new();
+    static INSTANCE: OnceLock<CompressedRistretto> = OnceLock::new();
     INSTANCE.get_or_init(|| RISTRETTO_NUMS_POINTS_COMPRESSED[0])
 }
 

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -5,6 +5,7 @@
 use alloc::{string::ToString, vec::Vec};
 use core::{
     borrow::Borrow,
+    cell::OnceCell,
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
@@ -19,7 +20,6 @@ use curve25519_dalek::{
     traits::MultiscalarMul,
 };
 use digest::{consts::U64, Digest};
-use once_cell::sync::OnceCell;
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeEq;
 use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, Hashable};


### PR DESCRIPTION
removes onecell, and replaces it with the rust version

This is breaking to due to the removal of no_std for now. This is required by the removal of oncecell and replaced with rust std version. 