### PR TITLE
fix: check the key byte length generically

### DIFF
--- a/src/compressed_key.rs
+++ b/src/compressed_key.rs
@@ -78,8 +78,8 @@ impl<T: PublicKey> CompressedKey<T> {
 }
 
 impl<T> CompressedKey<T> {
-    /// Create a new compressed key
-    pub fn new(key: &[u8]) -> CompressedKey<T> {
+    /// Create a new compressed key. NOTE: does not check the key length for T
+    fn new(key: &[u8]) -> CompressedKey<T> {
         Self {
             key: key.to_vec(),
             public_key: OnceLock::new(),
@@ -198,15 +198,15 @@ impl<T> Ord for CompressedKey<T> {
     }
 }
 
-impl<T> ByteArray for CompressedKey<T> {
+impl<T: PublicKey> ByteArray for CompressedKey<T> {
     /// Create a new `RistrettoPublicKey` instance form the given byte array. The constructor returns errors under
     /// the following circumstances:
     /// * The byte array is not exactly 32 bytes
     /// * The byte array does not represent a valid (compressed) point on the ristretto255 curve
     fn from_canonical_bytes(bytes: &[u8]) -> Result<CompressedKey<T>, ByteArrayError>
     where Self: Sized {
-        // Check the length here, because The Ristretto constructor panics rather than returning an error
-        if bytes.len() != 32 {
+        // Check the length here, because the new function does not
+        if bytes.len() != T::KEY_LEN {
             return Err(ByteArrayError::IncorrectLength {});
         }
         Ok(Self::new(bytes))

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -517,7 +517,7 @@ impl ByteArray for RistrettoPublicKey {
     fn from_canonical_bytes(bytes: &[u8]) -> Result<RistrettoPublicKey, ByteArrayError>
     where Self: Sized {
         // Check the length here, because The Ristretto constructor panics rather than returning an error
-        if bytes.len() != 32 {
+        if bytes.len() != Self::KEY_LEN {
             return Err(ByteArrayError::IncorrectLength {});
         }
         let compressed = CompressedRistretto::from_slice(bytes).map_err(|_| ByteArrayError::ConversionError {


### PR DESCRIPTION
CompressedKey<T> assumes the key length is 32 in `from_canonical_bytes`.

Made `CompressedKey::new` private since it is not used externally and needs to be used correctly, as it does not check byte length or if the compressed key bytes are valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced key management by refining validation routines to enforce dynamic key length requirements.
  - Improved encapsulation of internal key creation, ensuring that constraints are consistently applied for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->