### PR TITLE
fix: adds secret key conversions

### DIFF
--- a/src/ristretto/pedersen/commitment_factory.rs
+++ b/src/ristretto/pedersen/commitment_factory.rs
@@ -243,7 +243,7 @@ mod test {
     #[allow(clippy::redundant_clone)]
     fn derived_methods() {
         let factory = PedersenCommitmentFactory::default();
-        let k = RistrettoSecretKey::from(1024);
+        let k = RistrettoSecretKey::from(1024u64);
         let value = 2048;
         let c1 = factory.commit_value(&k, value);
 

--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -598,7 +598,7 @@ mod test {
     #[allow(clippy::redundant_clone)]
     fn derived_methods_singular() {
         let factory = ExtendedPedersenCommitmentFactory::default();
-        let k = RistrettoSecretKey::from(1024);
+        let k = RistrettoSecretKey::from(1024u64);
         let value = 2048;
         let c1 = factory.commit_value(&k, value);
 
@@ -651,7 +651,7 @@ mod test {
     fn derived_methods_extended() {
         for extension_degree in EXTENSION_DEGREE {
             let factory = ExtendedPedersenCommitmentFactory::new_with_extension_degree(extension_degree).unwrap();
-            let k_vec = vec![RistrettoSecretKey::from(1024); extension_degree as usize];
+            let k_vec = vec![RistrettoSecretKey::from(1024u64); extension_degree as usize];
             let value = 2048;
             let c1 = factory.commit_value_extended(&k_vec, value).unwrap();
 

--- a/src/ristretto/ristretto_com_and_pub_sig.rs
+++ b/src/ristretto/ristretto_com_and_pub_sig.rs
@@ -110,18 +110,18 @@ mod test {
             (
                 &PedersenCommitment::default(),
                 &RistrettoPublicKey::default(),
-                &RistrettoSecretKey::default(),
-                &RistrettoSecretKey::default(),
-                &RistrettoSecretKey::default()
+                &RistrettoSecretKey::ZERO,
+                &RistrettoSecretKey::ZERO,
+                &RistrettoSecretKey::ZERO,
             )
         );
 
         // Check all values returned from the getters
         assert_eq!(sig.ephemeral_commitment(), &PedersenCommitment::default());
         assert_eq!(sig.ephemeral_pubkey(), &RistrettoPublicKey::default());
-        assert_eq!(sig.u_a(), &RistrettoSecretKey::default());
-        assert_eq!(sig.u_x(), &RistrettoSecretKey::default());
-        assert_eq!(sig.u_y(), &RistrettoSecretKey::default());
+        assert_eq!(sig.u_a(), &RistrettoSecretKey::ZERO);
+        assert_eq!(sig.u_x(), &RistrettoSecretKey::ZERO);
+        assert_eq!(sig.u_y(), &RistrettoSecretKey::ZERO);
     }
 
     /// Create a signature, and then verify it. Also checks that some invalid signatures fail to verify


### PR DESCRIPTION
Adds the same conversions to RistrettoSecretKey supported by dalek's Scalar.
Adds `RistrettoSecretKey::ZERO` constant